### PR TITLE
Upgrade Keycloak to version 26.1.0

### DIFF
--- a/charts/czertainly/Chart.lock
+++ b/charts/czertainly/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: keycloak-internal
   repository: file://../keycloak-internal
-  version: 24.0.2-0-3
+  version: 26.1.0-develop
 - name: common-credential-provider
   repository: file://../common-credential-provider
   version: 1.3.3-2
@@ -59,5 +59,5 @@ dependencies:
 - name: scheduler-service
   repository: file://../scheduler-service
   version: 1.0.1-2
-digest: sha256:520a43f24c1a736781cc25edcde2d6208c1d7a1904ddb543a17c0630bec5d224
-generated: "2024-12-20T16:45:31.343507+01:00"
+digest: sha256:a5f45f229bba9e26fe7b76013ed1a46c5ce51f2d523b912fc9a61c52cd9f2968
+generated: "2025-01-28T13:49:31.662206997+01:00"

--- a/charts/czertainly/Chart.yaml
+++ b/charts/czertainly/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: file://../keycloak-internal
     tags:
       - keycloak-internal
-    version: 24.0.2-0-3
+    version: 26.1.0-develop
     alias: keycloakInternal
   - condition: commonCredentialProvider.enabled
     name: common-credential-provider

--- a/charts/keycloak-internal/Chart.yaml
+++ b/charts/keycloak-internal/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: trustLifecycleManagement
 apiVersion: v2
-appVersion: 24.0.2-0
+appVersion: 26.1.0-0
 name: keycloak-internal
 description: A Helm chart for internal Keycloak auth in CZERTAINLY platform.
 home: https://github.com/3KeyCompany/CZERTAINLY
@@ -29,4 +29,4 @@ sources:
   - https://github.com/3KeyCompany/CZERTAINLY
   - https://www.czertainly.com
   - https://docs.czertainly.com
-version: 24.0.2-0-3
+version: 26.1.0-develop

--- a/charts/keycloak-internal/README.md
+++ b/charts/keycloak-internal/README.md
@@ -170,12 +170,9 @@ The following values may be configured:
 | keycloak.dbSchema               | `"keycloak"`  | The database schema to be used                                                                              |
 | keycloak.admin.username         | `"admin"`     | Initial Keycloak master realm administrator username                                                        |
 | keycloak.admin.password         | `"admin"`     | Initial Keycloak master realm administrator password                                                        |
-| keycloak.hostnameStrict         | `false`       | Disables dynamically resolving the hostname from http request headers                                       |
-| keycloak.hostnameStrictHttps    | `false`       | Disables dynamically resolving the hostname from https request headers                                      |
-| keycloak.httpRelativePath       | `/kc`         | Set the path relative to `/` for serving resources. **Change only if you know what you are doing!**         |
+| keycloak.httpRelativePath       | `/kc`         | Set the path relative to `/` for serving resources. **Hardcoded in keycloak-optimized image, change only if you know what you are doing!**         |
 | keycloak.httpEnabled            | `true`        | Enables the HTTP listener                                                                                   |
-| keycloak.proxy                  | `"edge"`      | The proxy address forwarding mode, can be one of `none`, `edge`, `reencrypt`, `passthrough`                 |
-| keycloak.proxyAddressForwarding | `true`        | Enables proxy address forwarding                                                                            |
+| keycloak.proxyHeaders           | `forward`     | Should server accept `forward` or `xforward` values? See [officical documentation](https://www.keycloak.org/server/all-config#category-proxy) |
 
 #### CZERTAINLY realm parameters
 

--- a/charts/keycloak-internal/templates/keycloak-internal-deployment.yaml
+++ b/charts/keycloak-internal/templates/keycloak-internal-deployment.yaml
@@ -76,20 +76,24 @@ spec:
                 secretKeyRef:
                   name: keycloak-internal-secret
                   key: password
-            - name: KC_HOSTNAME_STRICT
-              value: {{ .Values.keycloak.hostnameStrict | quote }}
-            - name: KC_HOSTNAME_STRICT_HTTPS
-              value: {{ .Values.keycloak.hostnameStrictHttps | quote }}
             - name: JAVA_OPTS_APPEND
               value: "-Djgroups.dns.query=keycloak-service-internal-headless"
-            - name: KC_PROXY
-              value: {{ .Values.keycloak.proxy | quote }}
-            - name: KC_HTTP_PORT
-              value: {{ .Values.service.port | quote }}
+            - name: KC_HOSTNAME
+              value: https://{{ .Values.global.hostName }}{{ .Values.keycloak.httpRelativePath }}
             - name: KC_HTTP_ENABLED
               value: {{ .Values.keycloak.httpEnabled | quote }}
-            - name: PROXY_ADDRESS_FORWARDING
-              value: {{ .Values.keycloak.proxyAddressForwarding | quote }}
+            - name: KC_PROXY_HEADERS
+              value: {{ .Values.keycloak.proxyHeaders }}
+            # Following three variables KC_DB, KC_HTTP_RELATIVE_PATH and
+            # KC_HEALTH_ENABLED are needed when you need to run kc.sh in the
+            # image. They needs to be inline with valuses used to buld our
+            # optimized image: https://github.com/CZERTAINLY/CZERTAINLY-Keycloak-Optimized/
+            - name: KC_DB
+              value: postgres
+            - name: KC_HTTP_RELATIVE_PATH
+              value: {{ .Values.keycloak.httpRelativePath }}
+            - name: KC_HEALTH_ENABLED
+              value: "true"
             - name: KC_DB_SCHEMA
               value: {{ .Values.keycloak.dbSchema | quote }}
             # KC_DB_* env variables are needed for Keycloak

--- a/charts/keycloak-internal/values.yaml
+++ b/charts/keycloak-internal/values.yaml
@@ -106,7 +106,7 @@ image:
   registry: docker.io
   repository: 3keycompany
   name: czertainly-keycloak-optimized
-  tag: 24.0.2-0
+  tag: 26.1.0-0
   # the digest to be used instead of the tag
   digest: ""
   pullPolicy: IfNotPresent
@@ -244,8 +244,6 @@ keycloak:
   admin:
     username: "admin"
     password: "admin"
-  hostnameStrict: false
-  hostnameStrictHttps: false
   # cacheStack is set by the optimized build to kubernetes
   # cacheStack: "kubernetes"
   # relative path is important to run behind a reverse proxy
@@ -253,9 +251,8 @@ keycloak:
   # do not change this value if you are using the optimized build
   httpRelativePath: "/kc"
   httpEnabled: true
-  # none, edge, reencrypt, passthrough
-  proxy: "edge"
-  proxyAddressForwarding: true
+  # Use forwarded or xforwarded headers (more info: https://www.keycloak.org/server/all-config#category-proxy)
+  proxyHeaders: forwarded
 
 # configuration of the CZERTAINLY realm
 czertainly:


### PR DESCRIPTION
In version 25 new version of [hostname](https://www.keycloak.org/docs/latest/upgrading/index.html#new-hostname-options) related configuration was introduced and in version 26 it become mandatory to use the new version.  KC_HOSTNAME_STRICT, KC_HOSTNAME_STRICT_HTTPS, KC_PROXY, KC_HTTP_PORT and PROXY_ADDRESS_FORWARDING become obsoleted.

I've tested proposed changes in local my K8 as a new deployment also as upgrade from 2.13.1 in this case the deployment is publicaly registred in DNS  and I was testing with config:
```
keycloakInternal:
  createDbSchema: true
  logging:
   level: INFO,org.keycloak.saml:DEBUG,org.keycloak.broker.saml:DEBUG
  image:
    registry: docker.io
    repository: semik75
    name: keycloak
    tag: 26.1.0-semik3
apiGateway:
  trustedIps: "0.0.0.0/0,::/0"
#   hostAliases:
#     resolveInternalKeycloak: true
```

And I also tested new instalation and upgrade from 2.13.1 in appliance with hostname czertainly.local which isn't resolvovalbe in DNS, in this case I used also:
```
   hostAliases:
     resolveInternalKeycloak: true
```