### PR TITLE
Add optional resources for core deployment initContainer

### DIFF
--- a/charts/czertainly/docs/configurable-parameters.md
+++ b/charts/czertainly/docs/configurable-parameters.md
@@ -157,7 +157,7 @@ The following values may be configured for the CZERTAINLY core service:
 
 **cURL**
 
-| Parameter   ddd                                      | Default value  | Description                                         |
+| Parameter                                         | Default value  | Description                                         |
 |---------------------------------------------------|----------------|-----------------------------------------------------|
 | curl.image.registry                               | `docker.io`    | Docker registry name for the image                  |
 | curl.image.repository                             | `curlimages`   | Docker image repository name                        |

--- a/charts/czertainly/docs/configurable-parameters.md
+++ b/charts/czertainly/docs/configurable-parameters.md
@@ -157,7 +157,7 @@ The following values may be configured for the CZERTAINLY core service:
 
 **cURL**
 
-| Parameter                                         | Default value  | Description                                         |
+| Parameter   ddd                                      | Default value  | Description                                         |
 |---------------------------------------------------|----------------|-----------------------------------------------------|
 | curl.image.registry                               | `docker.io`    | Docker registry name for the image                  |
 | curl.image.repository                             | `curlimages`   | Docker image repository name                        |
@@ -171,6 +171,7 @@ The following values may be configured for the CZERTAINLY core service:
 | curl.image.securityContext.runAsNonRoot           | `true`         | Run the container as non-root user                  |
 | curl.image.securityContext.runAsUser              | `100`          | User ID for the container                           |
 | curl.image.securityContext.readOnlyRootFilesystem | `true`         | Run the container with read-only root filesystem    |
+| curl.image.resources                              | `{}`           | The resources for the container                     |
 
 **kubectl**
 

--- a/charts/czertainly/templates/core-deployment.yaml
+++ b/charts/czertainly/templates/core-deployment.yaml
@@ -52,6 +52,9 @@ spec:
         - name: wait-for-auth-service
           image: {{ include "czertainly.curl.image" . }}
           imagePullPolicy: {{ .Values.curl.image.pullPolicy }}
+          {{- if .Values.curl.image.resources }}
+          resources: {{- toYaml .Values.curl.image.resources | nindent 12 }}
+          {{- end }}
           {{- if .Values.curl.image.securityContext }}
           securityContext: {{- .Values.curl.image.securityContext | toYaml | nindent 12 }}
           {{- end }}

--- a/charts/czertainly/values.yaml
+++ b/charts/czertainly/values.yaml
@@ -289,6 +289,16 @@ curl:
       runAsUser: 100
       readOnlyRootFilesystem: true
     # it does not make sense to have probes for curl
+  resources: {}
+      # We follow recommendations and general guidelines to manage resources from:
+      # https://master.sdk.operatorframework.io/docs/best-practices/managing-resources/
+      # We recommend default requests for CPU and Memory, leaving the limits as a conscious
+      # choice for the user. If you do want to specify your own resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources'.
+      # requests:
+      #   cpu: 50m
+      #   memory: 150M
+      # limits: {}
 
 kubectl:
   image:


### PR DESCRIPTION
core deployment is missing option to configure curl image resource limits within initContainer