### PR TITLE
Add status service port to Kong API Gateway chart

### DIFF
--- a/charts/api-gateway-kong/README.md
+++ b/charts/api-gateway-kong/README.md
@@ -122,6 +122,8 @@ The following values may be configured:
 | service.admin.nodePort                       | `""`                         | Node port to be exposed for admin service (only works with `service.type: NodePort`)       |
 | service.consumer.port                        | `8000`                       | Port number of the exposed consumer service                                                |
 | service.consumer.nodePort                    | `""`                         | Node port to be exposed for consumer service (only works with `service.type: NodePort`)    |
+| service.status.port                          | `8100`                       | Port number of the exposed status service                                                  |
+| service.status.nodePort                      | `""`                         | Node port to be exposed for status service (only works with `service.type: NodePort`)      |
 | backend.core.service.name                    | `"core-service"`             | Name of the Core service                                                                   |
 | backend.core.service.port                    | `8080`                       | Port number of the Core service                                                            |
 | backend.core.service.apiUrl                  | `"/api"`                     | Base URL of the API requests                                                               |

--- a/charts/api-gateway-kong/templates/api-gateway-deployment.yaml
+++ b/charts/api-gateway-kong/templates/api-gateway-deployment.yaml
@@ -64,6 +64,8 @@ spec:
               value: "/dev/stderr"
             - name: KONG_ADMIN_LISTEN
               value: "0.0.0.0:8001, 0.0.0.0:8444 ssl"
+            - name: KONG_STATUS_LISTEN
+              value: "0.0.0.0:{{ .Values.service.status.port }}"
             - name: KONG_DECLARATIVE_CONFIG
               value: "/kong/declarative/kong.yml"
             - name: KONG_PLUGINS

--- a/charts/api-gateway-kong/templates/api-gateway-service.yaml
+++ b/charts/api-gateway-kong/templates/api-gateway-service.yaml
@@ -20,6 +20,12 @@ spec:
       {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.consumer.nodePort))) }}
       nodePort: {{ .Values.service.consumer.nodePort }}
       {{- end }}
+    - port: {{ .Values.service.status.port }}
+      protocol: "TCP"
+      name: status
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.status.nodePort))) }}
+      nodePort: {{ .Values.service.status.nodePort }}
+      {{- end }}
     {{- if $additionalPorts }}
       {{- $additionalPorts | nindent 4 }}
     {{- end }}

--- a/charts/api-gateway-kong/values.yaml
+++ b/charts/api-gateway-kong/values.yaml
@@ -234,6 +234,11 @@ service:
     # Node port to be exposed for consumer service (only works with service.type: NodePort)
     # choose port between 30000-32767
     nodePort: ""
+  status:
+    port: 8100
+    # Node port to be exposed for status service (only works with service.type: NodePort)
+    # choose port between 30000-32767
+    nodePort: ""
 
 hostName: "czertainly.local"
 


### PR DESCRIPTION
Introduces a configurable status service port and nodePort to the Helm chart for Kong API Gateway. Updates deployment, service, values, and documentation to support exposing the Kong status endpoint.