### PR TITLE
Remove default fsGroup

### DIFF
--- a/charts/messaging-rabbitmq/Chart.yaml
+++ b/charts/messaging-rabbitmq/Chart.yaml
@@ -28,4 +28,4 @@ sources:
   - https://github.com/3KeyCompany/CZERTAINLY
   - https://www.czertainly.com
   - https://docs.czertainly.com
-version: 3.13.7-2
+version: 3.13.7-3-develop

--- a/charts/messaging-rabbitmq/README.md
+++ b/charts/messaging-rabbitmq/README.md
@@ -114,7 +114,6 @@ The following values may be configured:
 | image.resources                              | `{}`                  | The resources for the container                             |
 | podLabels                                    | `{}`                  | Additional labels for the pod                               |
 | podAnnotations                               | `{}`                  | Additional annotations for the pod                          |
-| podSecurityContext.fsGroup                   | `999`                 | File system group for the pod                               |
 | volumes.ephemeral.type                       | `memory`              | Ephemeral volume type to be used                            |
 | volumes.ephemeral.sizeLimit                  | `"1Mi"`               | Ephemeral volume size limit                                 |
 | volumes.ephemeral.storageClassName           | `""`                  | Ephemeral volume storage class name for `storage` type      |

--- a/charts/messaging-rabbitmq/values.yaml
+++ b/charts/messaging-rabbitmq/values.yaml
@@ -226,7 +226,7 @@ podLabels: {}
 podAnnotations: {}
 
 podSecurityContext:
-  fsGroup: 999
+  # fsGroup: 999
   # runAsUser: 999
   # runAsGroup: 999
 


### PR DESCRIPTION
OpenShift uses UID/GID isolation between namespaces. Setting default fsGroup in Helm Chart causes impossibility to run such POD on default OpenShift enviroment. So it should be removed similarly like https://github.com/CZERTAINLY/CZERTAINLY-Helm-Charts/pull/238 