### PR TITLE
Fix/provisioning rabbitmq optional api key

### DIFF
--- a/charts/ilm/ci/develop-basic-values.yaml
+++ b/charts/ilm/ci/develop-basic-values.yaml
@@ -85,4 +85,5 @@ provisioningRabbitMq:
     pullPolicy: Always
   bootstrap:
     security:
+      enabled: true
       apiKey: "ci-test-key-placeholder-override"

--- a/charts/ilm/templates/_helpers.tpl
+++ b/charts/ilm/templates/_helpers.tpl
@@ -195,12 +195,21 @@ Render customized command and arguments, if any
 {{- end -}}
 
 {{/*
+Return true when the umbrella chart should use the in-cluster provisioning
+RabbitMQ subchart instead of an externally configured provisioning API.
+*/}}
+{{- define "ilm.provisioning.useLocalSubchart" -}}
+{{- if and (not .Values.global.provisioning.apiUrl) .Values.provisioningRabbitMq.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 Init container for provisioning per-instance AMQP queue.
 Rendered when proxy support is enabled and either the in-cluster bootstrap
 service or an external provisioning API is configured.
 Calls POST /api/v1/queues on the provisioning API with retry loop.
 */}}
 {{- define "ilm.initContainer.provisionQueue" -}}
+{{- $localProvisioningApi := eq (include "ilm.provisioning.useLocalSubchart" .) "true" }}
 {{- if and .Values.global.proxy.enabled (or .Values.provisioningRabbitMq.enabled .Values.global.provisioning.apiUrl) }}
 - name: provision-instance-queue
   image: {{ include "ilm.curl.image" . }}
@@ -218,18 +227,18 @@ Calls POST /api/v1/queues on the provisioning API with retry loop.
       {{- else }}
       value: {{ printf "http://provisioning-rabbitmq-service:%s" (toString .Values.provisioningRabbitMq.service.port) | quote }}
       {{- end }}
-    {{- if .Values.global.provisioning.apiKey }}
-    - name: PROVISIONING_API_KEY
-      valueFrom:
-        secretKeyRef:
-          name: provisioning-secret
-          key: provisioningApiKey
-    {{- else if .Values.provisioningRabbitMq.enabled }}
+    {{- if and $localProvisioningApi .Values.provisioningRabbitMq.bootstrap.security.enabled }}
     - name: PROVISIONING_API_KEY
       valueFrom:
         secretKeyRef:
           name: provisioning-rabbitmq-secret
           key: securityApiKey
+    {{- else if and (not $localProvisioningApi) .Values.global.provisioning.apiKey }}
+    - name: PROVISIONING_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: provisioning-secret
+          key: provisioningApiKey
     {{- end }}
   command:
     - /bin/sh

--- a/charts/ilm/templates/core-deployment.yaml
+++ b/charts/ilm/templates/core-deployment.yaml
@@ -13,6 +13,7 @@
 {{- $messagingHost := .Values.messaging.host }}
 {{- $messagingAmqpPort := .Values.messaging.amqp.port }}
 {{- $externalMessaging := pluck "enabled" .Values.global.messaging.external .Values.messaging.external | compact | first }}
+{{- $localProvisioningApi := eq (include "ilm.provisioning.useLocalSubchart" .) "true" }}
 {{- if $externalMessaging }}
 {{- $messagingHost = pluck "host" .Values.global.messaging.external .Values.messaging.external | compact | first }}
 {{- $messagingAmqpPort = pluck "port" .Values.global.messaging.external.amqp .Values.messaging.external.amqp | compact | first }}
@@ -259,12 +260,21 @@ spec:
               {{- else }}
               value: ""
               {{- end }}
-            {{- if .Values.global.provisioning.apiKey }}
+            {{- if and $localProvisioningApi .Values.provisioningRabbitMq.bootstrap.security.enabled }}
+            - name: PROVISIONING_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: provisioning-rabbitmq-secret
+                  key: securityApiKey
+            {{- else if and (not $localProvisioningApi) .Values.global.provisioning.apiKey }}
             - name: PROVISIONING_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: provisioning-secret
                   key: provisioningApiKey
+            {{- else }}
+            - name: PROVISIONING_API_KEY
+              value: ""
             {{- end }}
             - name: PROXY_ENABLED
               value: {{ .Values.global.proxy.enabled | quote }}

--- a/charts/provisioning-rabbitmq/README.md
+++ b/charts/provisioning-rabbitmq/README.md
@@ -139,7 +139,8 @@ The following values may be configured:
 | bootstrap.proxy.amqpUrl                      | `"amqp://messaging-service:5672"`    | External AMQP URL that proxy services use to connect to RabbitMQ (may differ from internal host when using NodePort/LB) |
 | bootstrap.proxy.exchange                     | `"czertainly-proxy"`                 | RabbitMQ exchange name for proxy communication                                                                           |
 | bootstrap.proxy.responseQueue                | `"core"`                             | RabbitMQ queue name for proxy responses                                                                                  |
-| bootstrap.security.apiKey                    | `"your-secret-api-key"`              | API key used to secure the bootstrap service endpoints. **Must be changed to a secure value.**                           |
+| bootstrap.security.enabled                   | `false`                              | Enable the X-API-Key filter on bootstrap endpoints. When `false`, endpoints are unauthenticated.                         |
+| bootstrap.security.apiKey                    | `""`                                 | API key used to secure the bootstrap service endpoints. Required when `bootstrap.security.enabled` is `true`.            |
 | bootstrap.token.signingKey                   | `""`                                 | JWT signing key used to sign tokens for proxy services. Optional; must be at least 32 characters if set.                |
 | serviceAccount.create                        | `true`                               | Specifies whether a service account should be created                                                                    |
 | serviceAccount.annotations                   | `{}`                                 | Annotations to add to the service account                                                                                |

--- a/charts/provisioning-rabbitmq/ci/develop-values.yaml
+++ b/charts/provisioning-rabbitmq/ci/develop-values.yaml
@@ -6,4 +6,5 @@ messaging:
 
 bootstrap:
   security:
+    enabled: true
     apiKey: "ci-test-key-placeholder-override"

--- a/charts/provisioning-rabbitmq/templates/NOTES.txt
+++ b/charts/provisioning-rabbitmq/templates/NOTES.txt
@@ -9,7 +9,12 @@ API documentation:
   GET    /api/v1/proxies/{proxyCode}/installation - Get proxy installation instructions
 
 Authentication:
+{{- if .Values.bootstrap.security.enabled }}
   All API calls require the X-API-Key header with the configured security API key.
+{{- else }}
+  API calls are unauthenticated because bootstrap.security.enabled is false.
+  Set bootstrap.security.enabled=true and bootstrap.security.apiKey to require X-API-Key.
+{{- end }}
 
 Health check:
   http://provisioning-rabbitmq-service:{{ .Values.service.port }}/actuator/health

--- a/charts/provisioning-rabbitmq/templates/provisioning-rabbitmq-deployment.yaml
+++ b/charts/provisioning-rabbitmq/templates/provisioning-rabbitmq-deployment.yaml
@@ -148,11 +148,15 @@ spec:
               value: {{ .Values.bootstrap.proxy.exchange | quote }}
             - name: PROXY_RESPONSE_QUEUE
               value: {{ .Values.bootstrap.proxy.responseQueue | quote }}
+            - name: SECURITY_API_KEY_ENABLED
+              value: {{ .Values.bootstrap.security.enabled | quote }}
+            {{- if .Values.bootstrap.security.enabled }}
             - name: SECURITY_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: provisioning-rabbitmq-secret
                   key: securityApiKey
+            {{- end }}
             {{- if .Values.bootstrap.token.signingKey }}
             - name: TOKEN_SIGNING_KEY
               valueFrom:

--- a/charts/provisioning-rabbitmq/templates/provisioning-rabbitmq-secret.yaml
+++ b/charts/provisioning-rabbitmq/templates/provisioning-rabbitmq-secret.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.bootstrap.security.enabled (not .Values.bootstrap.security.apiKey) }}
+{{- $securityApiKey := .Values.bootstrap.security.apiKey | default "" | trim }}
+{{- if and .Values.bootstrap.security.enabled (not $securityApiKey) }}
 {{- fail "bootstrap.security.apiKey must be set when bootstrap.security.enabled is true" }}
 {{- end }}
 {{- if or .Values.bootstrap.security.enabled .Values.bootstrap.token.signingKey }}
@@ -8,7 +9,7 @@ metadata:
   name: provisioning-rabbitmq-secret
 data:
   {{- if .Values.bootstrap.security.enabled }}
-  securityApiKey: {{ .Values.bootstrap.security.apiKey | b64enc | quote }}
+  securityApiKey: {{ $securityApiKey | b64enc | quote }}
   {{- end }}
   {{- if .Values.bootstrap.token.signingKey }}
   tokenSigningKey: {{ .Values.bootstrap.token.signingKey | b64enc | quote }}

--- a/charts/provisioning-rabbitmq/templates/provisioning-rabbitmq-secret.yaml
+++ b/charts/provisioning-rabbitmq/templates/provisioning-rabbitmq-secret.yaml
@@ -1,12 +1,16 @@
+{{- if and .Values.bootstrap.security.enabled (not .Values.bootstrap.security.apiKey) }}
+{{- fail "bootstrap.security.apiKey must be set when bootstrap.security.enabled is true" }}
+{{- end }}
+{{- if or .Values.bootstrap.security.enabled .Values.bootstrap.token.signingKey }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: provisioning-rabbitmq-secret
 data:
-  {{- if or (not .Values.bootstrap.security.apiKey) (eq .Values.bootstrap.security.apiKey "your-secret-api-key") }}
-  {{- fail "bootstrap.security.apiKey must be set to a secure value (do not use the default placeholder)" }}
-  {{- end }}
+  {{- if .Values.bootstrap.security.enabled }}
   securityApiKey: {{ .Values.bootstrap.security.apiKey | b64enc | quote }}
+  {{- end }}
   {{- if .Values.bootstrap.token.signingKey }}
   tokenSigningKey: {{ .Values.bootstrap.token.signingKey | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/provisioning-rabbitmq/values.yaml
+++ b/charts/provisioning-rabbitmq/values.yaml
@@ -163,7 +163,9 @@ bootstrap:
     exchange: "czertainly-proxy"
     responseQueue: "core"
   security:
-    apiKey: "your-secret-api-key"
+    # When true, the X-API-Key filter is enabled and apiKey must be set.
+    enabled: false
+    apiKey: ""
   token:
     # JWT signing key – must be at least 32 characters.
     signingKey: ""


### PR DESCRIPTION
## Summary

  The chart required `bootstrap.security.apiKey`, but the app gates its X-API-Key
  filter on `SECURITY_API_KEY_ENABLED` (default `false` in `application.yml`).
  Adds a `bootstrap.security.enabled` toggle so the chart matches the app.
  - Subchart: gate the `Secret`, `securityApiKey` data field, and `SECURITY_API_KEY`
    env on `bootstrap.security.enabled`. Always wire `SECURITY_API_KEY_ENABLED`.
    Trim+validate `apiKey`. `fail` only when `enabled: true` and key is empty.
  - Umbrella: pick the right secret for `PROVISIONING_API_KEY` (core deployment
    and `provisionQueue` init) based on local subchart vs. external `apiUrl`,
    and on the new `enabled` flag. Closes a latent bug where the umbrella
    referenced `securityApiKey` after the field became conditional.
  - `NOTES.txt` now reflects the actual auth posture.

  Signing key (`bootstrap.token.signingKey`) was already optional — unchanged.

  ## Behavior change

  Users with `provisioningRabbitMq.enabled=true` and no explicit
  `bootstrap.security.enabled` will now run with the X-API-Key filter **disabled**.
  Set `bootstrap.security.enabled=true` + `apiKey` to keep prior behavior.

  ## Test plan

  - [x] `helm lint` clean for both charts
  - [x] `helm template` subchart: defaults / enabled+key / enabled w/o key (fails) /
        signingKey only
  - [x] `helm template` umbrella: CI values / subchart-on-security-off /
        external `apiUrl`+global key
  - [ ] `ct install` on KinD