### PR TITLE
Add external-authority-provider subchart

### DIFF
--- a/charts/external-authority-provider/.helmignore
+++ b/charts/external-authority-provider/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/external-authority-provider/Chart.lock
+++ b/charts/external-authority-provider/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: ilm-lib
+  repository: file://../ilm-lib
+  version: 1.4.2-1-develop
+digest: sha256:c36d87665a6deea9e4a51739e14e7a3ad2e968d4a40f0851be4a8a574018aebc
+generated: "2026-05-10T10:31:05.096883+02:00"

--- a/charts/external-authority-provider/Chart.yaml
+++ b/charts/external-authority-provider/Chart.yaml
@@ -1,0 +1,32 @@
+annotations:
+  category: trustLifecycleManagement
+apiVersion: v2
+appVersion: 1.0.0
+name: external-authority-provider
+description: A Helm chart for External Authority Provider for ILM platform.
+home: https://github.com/OmniTrustILM/ilm
+icon: https://raw.githubusercontent.com/OmniTrustILM/ilm/main/icon/ot-icon-color.svg
+dependencies:
+  - name: ilm-lib
+    # repository: oci://hub.omnitrustregistry.com/ilm-helm
+    repository: file://../ilm-lib
+    version: 1.4.2-1-develop
+keywords:
+  - ilm
+  - trust
+  - management
+  - lifecycle
+  - platform
+  - external
+  - authority
+  - provider
+maintainers:
+  - name: OmniTrustILM
+    email: ilm@omnitrust.com
+    url: https://github.com/OmniTrustILM/helm-charts
+type: application
+sources:
+  - https://github.com/OmniTrustILM/ilm
+  - https://omnitrust.com
+  - https://docs.otilm.com
+version: 1.0.0-develop

--- a/charts/external-authority-provider/README.md
+++ b/charts/external-authority-provider/README.md
@@ -29,7 +29,7 @@ Copy the default `values.yaml` from the Helm chart and modify the values accordi
 ```bash
 helm show values oci://hub.omnitrustregistry.com/ilm-helm/external-authority-provider > values.yaml
 ```
-Now edit the `values.yaml` according to your desired stated, see [Configurable parameters](#configurable-parameters) for more information.
+Now edit the `values.yaml` according to your desired state, see [Configurable parameters](#configurable-parameters) for more information.
 
 **Install**
 
@@ -109,7 +109,7 @@ The following values may be configured:
 | nameOverride                                 | `external-authority-provider`      | Override for the chart name. Used as the `app.kubernetes.io/name` selector label value and as input to the fullname helper. |
 | fullnameOverride                             | `""`                               | Override for the fully qualified app name.                                                                                  |
 | image.registry                               | `hub.omnitrustregistry.com`        | Docker registry name for the image                                                                                          |
-| image.repository                             | `ilm`                              | Docker image repository name                                                                                                |
+| image.repository                             | `ilm-private`                      | Docker image repository name                                                                                                |
 | image.name                                   | `external-authority-provider`      | Docker image name                                                                                                           |
 | image.tag                                    | `1.0.0`                            | Docker image tag                                                                                                            |
 | image.digest                                 | `""`                               | Docker image digest, will override tag if specified                                                                         |
@@ -144,6 +144,19 @@ The following values may be configured:
 | serviceAccount.create                        | `true`                             | Specifies whether a service account should be created                                                                       |
 | serviceAccount.annotations                   | `{}`                               | Annotations to add to the service account                                                                                   |
 | serviceAccount.name                          | `"external-authority-provider-sa"` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template      |
+
+#### Identify validation parameters
+
+The connector exposes a set of boolean knobs that control how `identifyCertificate` validates a certificate against the configured CA chain. Per-property semantics live in the connector's `IdentifyValidationProperties` (`com.otilm.ca.connector.external.config`); defaults match the connector's shipping behaviour (signature-only validation).
+
+| Parameter                                   | Default value | Description                                                                                       |
+|---------------------------------------------|---------------|---------------------------------------------------------------------------------------------------|
+| identify.verifySignature                    | `true`        | Verify the input certificate's signature under the configured CA's key                            |
+| identify.requireAuthorityKeyIdentifierMatch | `false`       | Require the input cert's AKI to match a configured CA's SKI                                       |
+| identify.checkValidity                      | `false`       | Require both the input cert and the matching CA cert to be currently valid                        |
+| identify.requireCaBasicConstraint           | `false`       | Require the matching CA cert's BasicConstraints `cA = true`                                       |
+| identify.requireKeyCertSignKeyUsage         | `false`       | Require the matching CA cert's KeyUsage to include `keyCertSign`                                  |
+| identify.pkix                               | `false`       | Run the JDK's full PKIX path validation (RFC 5280); takes precedence over individual flags above  |
 
 #### Customization parameters
 

--- a/charts/external-authority-provider/README.md
+++ b/charts/external-authority-provider/README.md
@@ -1,0 +1,192 @@
+# External Authority Provider - ILM
+
+> This repository is part of the commercial open-source project ILM. You can find more information about the project at [ILM](https://github.com/OmniTrustILM/ilm) repository, including the contribution guide.
+
+This repository contains [Helm](https://helm.sh/) charts as part of the ILM platform.
+
+## Prerequisites
+- Kubernetes 1.19+
+- Helm 3.8.0+
+- PostgreSQL 11+
+
+## Using this Chart
+
+### Installation
+
+**Create namespace**
+
+We’ll need to define a Kubernetes namespace where the resources created by the Chart should be installed:
+```bash
+kubectl create namespace ilm
+```
+
+**Create `values.yaml`**
+
+> **Note**
+> You can also use `--set` options for the helm to apply configuration for the chart.
+
+Copy the default `values.yaml` from the Helm chart and modify the values accordingly:
+```bash
+helm show values oci://hub.omnitrustregistry.com/ilm-helm/external-authority-provider > values.yaml
+```
+Now edit the `values.yaml` according to your desired stated, see [Configurable parameters](#configurable-parameters) for more information.
+
+**Install**
+
+For the basic installation, run:
+```bash
+helm install --namespace ilm -f values.yaml ilm-external-authority-provider oci://hub.omnitrustregistry.com/ilm-helm/external-authority-provider
+```
+
+**Save your configuration**
+
+Always make sure you save the `values.yaml` and all `--set` and `--set-file` options you used. You will need to use the same options when you upgrade to new versions with Helm. In case you are changing the configuration, save the new configuration.
+
+### Upgrade
+
+> **Warning**
+> Be sure that you always save your previous configuration!
+
+For upgrading the installation, update your configuration and run:
+```bash
+helm upgrade --namespace ilm -f values.yaml ilm-external-authority-provider oci://hub.omnitrustregistry.com/ilm-helm/external-authority-provider
+```
+
+### Uninstall
+
+You can use the `helm uninstall` command to uninstall the application:
+```bash
+helm uninstall --namespace ilm ilm-external-authority-provider
+```
+
+## Configurable parameters
+
+You can find current values in the [values.yaml](values.yaml).
+You can also Specify each parameter using the `--set` or `--set-file` argument to `helm install`.
+
+### Global parameters
+
+Global values are used to define common parameters for the chart and all its sub-charts by exactly the same name.
+
+| Parameter                                 | Default value          | Description                                                           |
+|-------------------------------------------|------------------------|-----------------------------------------------------------------------|
+| global.replicaCount                       | `1`                    | Number of replicas for the application                                |
+| global.image.registry                     | `""`                   | Global docker registry name                                           |
+| global.image.repository                   | `""`                   | Global docker image repository name                                   |
+| global.image.pullSecrets                  | `[]`                   | Global array of secret names for image pull                           |
+| global.volumes.ephemeral.type             | `""`                   | Global ephemeral volume type to be used                               |
+| global.volumes.ephemeral.sizeLimit        | `""`                   | Global ephemeral volume size limit                                    |
+| global.volumes.ephemeral.storageClassName | `""`                   | Global ephemeral volume storage class name for `storage` type         |
+| global.volumes.ephemeral.custom           | `{}`                   | Global custom definition of the ephemeral volume for `custom` type    |
+| global.database.type                      | `""`                   | Type of the database, currently only `postgresql` is supported        |
+| global.database.host                      | `""`                   | Host where is the database located                                    |
+| global.database.port                      | `""`                   | Port on which is the database listening                               |
+| global.database.name                      | `""`                   | Database name                                                         |
+| global.database.username                  | `""`                   | Username to access the database                                       |
+| global.database.password                  | `""`                   | Password to access the database                                       |
+| global.database.pgBouncer.enabled         | `true`                 | Enable pgBouncer for database connection pooling and management       |
+| global.database.pgBouncer.host            | `"pg-bouncer-service"` | Host where is the pgBouncer located                                   |
+| global.database.pgBouncer.port            | `5432`                 | Port on which is the pgBouncer listening                              |
+| global.trusted.certificates               | `""`                   | List of additional CA certificates that should be trusted             |
+| global.httpProxy                          | `""`                   | Proxy to be used to access external resources through http            |
+| global.httpsProxy                         | `""`                   | Proxy to be used to access external resources through https           |
+| global.noProxy                            | `""`                   | Defines list of external resources that should not use proxy settings |
+| global.initContainers                     | `[]`                   | Global init containers                                                |
+| global.sidecarContainers                  | `[]`                   | Global sidecar containers                                             |
+| global.additionalVolumes                  | `[]`                   | Global additional volumes                                             |
+| global.additionalVolumeMounts             | `[]`                   | Global additional volume mounts                                       |
+| global.additionalPorts                    | `[]`                   | Global additional ports                                               |
+| global.additionalEnv.variables            | `[]`                   | Global additional environment variables                               |
+| global.additionalEnv.secrets              | `[]`                   | Global additional environment secrets                                 |
+| global.additionalEnv.configMaps           | `[]`                   | Global additional environment config maps                             |
+
+### Local parameters
+
+The following values may be configured:
+
+| Parameter                                    | Default value                      | Description                                                                                                                 |
+|----------------------------------------------|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| nameOverride                                 | `external-authority-provider`      | Override for the chart name. Used as the `app.kubernetes.io/name` selector label value and as input to the fullname helper. |
+| fullnameOverride                             | `""`                               | Override for the fully qualified app name.                                                                                  |
+| image.registry                               | `hub.omnitrustregistry.com`        | Docker registry name for the image                                                                                          |
+| image.repository                             | `ilm`                              | Docker image repository name                                                                                                |
+| image.name                                   | `external-authority-provider`      | Docker image name                                                                                                           |
+| image.tag                                    | `1.0.0`                            | Docker image tag                                                                                                            |
+| image.digest                                 | `""`                               | Docker image digest, will override tag if specified                                                                         |
+| image.pullPolicy                             | `IfNotPresent`                     | Image pull policy                                                                                                           |
+| image.pullSecrets                            | `[]`                               | Array of secret names for image pull                                                                                        |
+| image.command                                | `[]`                               | Override the default command                                                                                                |
+| image.args                                   | `[]`                               | Override the default args                                                                                                   |
+| image.securityContext.runAsNonRoot           | `true`                             | Run the container as non-root user                                                                                          |
+| image.securityContext.readOnlyRootFilesystem | `true`                             | Run the container with read-only root filesystem                                                                            |
+| image.resources                              | `{}`                               | The resources for the container                                                                                             |
+| podLabels                                    | `{}`                               | Labels to be added to the pod                                                                                               |
+| podAnnotations                               | `{}`                               | Annotations to be added to the pod                                                                                          |
+| podSecurityContext                           | `{}`                               | Pod security context                                                                                                        |
+| volumes.ephemeral.type                       | `memory`                           | Ephemeral volume type to be used                                                                                            |
+| volumes.ephemeral.sizeLimit                  | `"1Mi"`                            | Ephemeral volume size limit                                                                                                 |
+| volumes.ephemeral.storageClassName           | `""`                               | Ephemeral volume storage class name for `storage` type                                                                      |
+| volumes.ephemeral.custom                     | `{}`                               | Custom definition of the ephemeral volume for `custom` type                                                                 |
+| database.type                                | `"postgresql"`                     | Type of the database, currently only `postgresql` is supported                                                              |
+| database.host                                | `"host.docker.internal"`           | Host where is the database located                                                                                          |
+| database.port                                | `5432`                             | Port on which is the database listening                                                                                     |
+| database.name                                | `"ilmdb"`                          | Database name                                                                                                               |
+| database.schema                              | `"externalap"`                     | Database schema for the connector tables (Flyway-managed)                                                                   |
+| database.username                            | `"ilmuser"`                        | Username to access the database                                                                                             |
+| database.password                            | `"your-strong-password"`           | Password to access the database                                                                                             |
+| trusted.certificates                         | `""`                               | List of additional CA certificates that should be trusted                                                                   |
+| httpProxy                                    | `""`                               | Proxy to be used to access external resources through http                                                                  |
+| httpsProxy                                   | `""`                               | Proxy to be used to access external resources through https                                                                 |
+| noProxy                                      | `""`                               | Defines list of external resources that should not use proxy settings                                                       |
+| logging.level                                | `"INFO"`                           | Allowed values are `"INFO"`, `"DEBUG"`, `"WARN"`, `"TRACE"`                                                                 |
+| service.type                                 | `"ClusterIP"`                      | Type of the service that is exposed                                                                                         |
+| service.port                                 | `8080`                             | Port number of the exposed service                                                                                          |
+| serviceAccount.create                        | `true`                             | Specifies whether a service account should be created                                                                       |
+| serviceAccount.annotations                   | `{}`                               | Annotations to add to the service account                                                                                   |
+| serviceAccount.name                          | `"external-authority-provider-sa"` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template      |
+
+#### Customization parameters
+
+| Parameter                | Default value | Description                        |
+|--------------------------|---------------|------------------------------------|
+| initContainers           | `[]`          | Init containers                    |
+| sidecarContainers        | `[]`          | Sidecar containers                 |
+| additionalVolumes        | `[]`          | Additional volumes                 |
+| additionalVolumeMounts   | `[]`          | Additional volume mounts           |
+| additionalPorts          | `[]`          | Additional ports                   |
+| additionalEnv.variables  | `[]`          | Additional environment variables   |
+| additionalEnv.secrets    | `[]`          | Additional environment secrets     |
+| additionalEnv.configMaps | `[]`          | Additional environment config maps |
+
+#### Probes parameters
+
+For mode details about probes, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
+
+| Parameter                                  | Default value | Description                                                                        |
+|--------------------------------------------|---------------|------------------------------------------------------------------------------------|
+| image.probes.liveness.enabled              | `false`       | Enable/disable liveness probe                                                      |
+| image.probes.liveness.custom               | `{}`          | Custom liveness probe command. When defined, it will override the default command  |
+| image.probes.liveness.initialDelaySeconds  | `60`          | Initial delay seconds for liveness probe                                           |
+| image.probes.liveness.timeoutSeconds       | `5`           | Timeout seconds for liveness probe                                                 |
+| image.probes.liveness.periodSeconds        | `10`          | Period seconds for liveness probe                                                  |
+| image.probes.liveness.successThreshold     | `1`           | Success threshold for liveness probe                                               |
+| image.probes.liveness.failureThreshold     | `3`           | Failure threshold for liveness probe                                               |
+| image.probes.readiness.enabled             | `true`        | Enable/disable readiness probe                                                     |
+| image.probes.readiness.custom              | `{}`          | Custom readiness probe command. When defined, it will override the default command |
+| image.probes.readiness.initialDelaySeconds | `15`          | Initial delay seconds for readiness probe                                          |
+| image.probes.readiness.timeoutSeconds      | `5`           | Timeout seconds for readiness probe                                                |
+| image.probes.readiness.periodSeconds       | `10`          | Period seconds for readiness probe                                                 |
+| image.probes.readiness.successThreshold    | `1`           | Success threshold for readiness probe                                              |
+| image.probes.readiness.failureThreshold    | `3`           | Failure threshold for readiness probe                                              |
+| image.probes.startup.enabled               | `true`        | Enable/disable startup probe                                                       |
+| image.probes.startup.custom                | `{}`          | Custom startup probe command. When defined, it will override the default command   |
+| image.probes.startup.initialDelaySeconds   | `15`          | Initial delay seconds for startup probe                                            |
+| image.probes.startup.timeoutSeconds        | `5`           | Timeout seconds for startup probe                                                  |
+| image.probes.startup.periodSeconds         | `10`          | Period seconds for startup probe                                                   |
+| image.probes.startup.successThreshold      | `1`           | Success threshold for startup probe                                                |
+| image.probes.startup.failureThreshold      | `45`          | Failure threshold for startup probe                                                |
+
+### Additional parameters
+
+Additional parameters may be found in the [values.yaml](values.yaml) and dependencies.
+See dependent charts for the description of available parameters.

--- a/charts/external-authority-provider/ci/develop-values.yaml
+++ b/charts/external-authority-provider/ci/develop-values.yaml
@@ -8,3 +8,5 @@ database:
 
 image:
   tag: develop-latest
+  pullSecrets:
+    - ilmcred

--- a/charts/external-authority-provider/ci/develop-values.yaml
+++ b/charts/external-authority-provider/ci/develop-values.yaml
@@ -1,0 +1,10 @@
+global:
+  database:
+    pgBouncer:
+      enabled: false
+
+database:
+  host: "172.17.0.1"
+
+image:
+  tag: develop-latest

--- a/charts/external-authority-provider/templates/NOTES.txt
+++ b/charts/external-authority-provider/templates/NOTES.txt
@@ -1,0 +1,7 @@
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+APP VERSION: {{ .Chart.AppVersion }}
+
+** Please be patient while the chart is being deployed **
+
+Follow the steps described in the documentation in order to register the connector within the ILM platform.

--- a/charts/external-authority-provider/templates/_helpers.tpl
+++ b/charts/external-authority-provider/templates/_helpers.tpl
@@ -1,0 +1,151 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "external-authority-provider.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "external-authority-provider.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "external-authority-provider.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "external-authority-provider.labels" -}}
+helm.sh/chart: {{ include "external-authority-provider.chart" . }}
+{{ include "external-authority-provider.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "external-authority-provider.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "external-authority-provider.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "external-authority-provider.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "external-authority-provider.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the image name
+*/}}
+{{- define "external-authority-provider.image" -}}
+{{ include "ilm-lib.images.image" (dict "image" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the image name of the curl
+*/}}
+{{- define "external-authority-provider.curl.image" -}}
+{{ include "ilm-lib.images.image" (dict "image" .Values.curl.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the image pull secret names
+*/}}
+{{- define "external-authority-provider.imagePullSecrets" -}}
+{{ include "ilm-lib.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the ephemeral volume configuration
+*/}}
+{{- define "external-authority-provider.ephemeralVolume" -}}
+{{ include "ilm-lib.volumes.ephemeral" (dict "volumes" .Values.volumes "global" .Values.global.volumes) }}
+{{- end -}}
+
+{{/*
+Render init containers, if any
+*/}}
+{{- define "external-authority-provider.customization.initContainers" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.initContainers .Values.initContainers) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render sidecar containers, if any
+*/}}
+{{- define "external-authority-provider.customization.sidecarContainers" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.sidecarContainers .Values.sidecarContainers) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render additional volumes, if any
+*/}}
+{{- define "external-authority-provider.customization.volumes" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalVolumes .Values.additionalVolumes) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render additional volume mounts, if any
+*/}}
+{{- define "external-authority-provider.customization.volumeMounts" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalVolumeMounts .Values.additionalVolumeMounts) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render customized ports, if any
+*/}}
+{{- define "external-authority-provider.customization.ports" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalPorts .Values.additionalPorts) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render customized environment variables, if any
+*/}}
+{{- define "external-authority-provider.customization.env" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalEnv.variables .Values.additionalEnv.variables) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render customized environment variables from configmaps and secrets, if any
+*/}}
+{{- define "external-authority-provider.customization.envFrom" -}}
+{{- include "ilm-lib.customizations.render.configMapEnv" ( dict "parts" (list .Values.global.additionalEnv.configMaps .Values.additionalEnv.configMaps) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.secretEnv" ( dict "parts" (list .Values.global.additionalEnv.secrets .Values.additionalEnv.secrets) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render customized command and arguments, if any
+*/}}
+{{- define "external-authority-provider.image.command" -}}
+{{- include "ilm-lib.tplvalues.render" (dict "value" .Values.image.command "context" $) }}
+{{- end -}}
+
+{{- define "external-authority-provider.image.args" -}}
+{{- include "ilm-lib.tplvalues.render" (dict "value" .Values.image.args "context" $) }}
+{{- end -}}

--- a/charts/external-authority-provider/templates/external-authority-provider-deployment.yaml
+++ b/charts/external-authority-provider/templates/external-authority-provider-deployment.yaml
@@ -1,0 +1,191 @@
+{{- $replicaCount := pluck "replicaCount" .Values.global .Values | compact | first }}
+{{- $httpProxy := pluck "httpProxy" .Values.global .Values | compact | first }}
+{{- $httpsProxy := pluck "httpsProxy" .Values.global .Values | compact | first }}
+{{- $noProxy := pluck "noProxy" .Values.global .Values | compact | first }}
+{{- $additionalInitContainers := (include "external-authority-provider.customization.initContainers" $) }}
+{{- $additionalSidecarContainers := (include "external-authority-provider.customization.sidecarContainers" $) }}
+{{- $additionalVolumes := (include "external-authority-provider.customization.volumes" $) }}
+{{- $additionalVolumeMounts := (include "external-authority-provider.customization.volumeMounts" $) }}
+{{- $additionalEnv := (include "external-authority-provider.customization.env" $) }}
+{{- $additionalEnvFrom := (include "external-authority-provider.customization.envFrom" $) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-authority-provider-deployment
+  labels:
+    {{- include "external-authority-provider.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ $replicaCount | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "external-authority-provider.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "external-authority-provider.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+        # when the list of the trusted certificates is changed, restart deployment
+        checksum/trusted-certificates-local: {{ include (print $.Template.BasePath "/trusted-certificates-secret.yaml") . | sha256sum }}
+        {{- if .Values.global.trusted.certificates }}
+        checksum/trusted-certificates-global: {{ include ("ilm-lib.trusted.certificates.secret.global") . | sha256sum }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "external-authority-provider.imagePullSecrets" . | indent 6 }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- .Values.podSecurityContext | toYaml | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ template "external-authority-provider.serviceAccountName" . }}
+      {{- if $additionalInitContainers }}
+      initContainers:
+        {{- $additionalInitContainers | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: external-authority-provider
+          image: {{ include "external-authority-provider.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.image.command }}
+          command: {{- include "external-authority-provider.image.command" . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.image.args }}
+          args: {{- include "external-authority-provider.image.args" . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: PORT
+              value: {{ .Values.service.port | quote }}
+            {{- if $httpProxy }}
+            - name: HTTP_PROXY
+              value: {{ $httpProxy }}
+            {{- end }}
+            {{- if $httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ $httpsProxy }}
+            {{- end }}
+            {{- if $noProxy }}
+            - name: NO_PROXY
+              value: {{ $noProxy }}
+            {{- end }}
+            - name: LOGGING_LEVEL_COM_CZERTAINLY
+              value: {{ .Values.logging.level | quote }}
+            - name: LOGGING_LEVEL_COM_OTILM
+              value: {{ .Values.logging.level | quote }}
+            - name: JDBC_URL
+              value: {{ include "ilm-lib.util.format.jdbcUrl" (list . "?characterEncoding=UTF-8") | quote }}
+            - name: JDBC_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: external-authority-provider-secret
+                  key: username
+            - name: JDBC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: external-authority-provider-secret
+                  key: password
+            - name: DB_SCHEMA
+              value: {{ .Values.database.schema | quote }}
+            {{- if or .Values.global.trusted.certificates .Values.trusted.certificates }}
+            - name: TRUSTED_CERTIFICATES
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.global.trusted.certificates }}
+                  name: trusted-certificates
+                  {{- else if .Values.trusted.certificates }}
+                  name: trusted-certificates-{{ .Chart.Name | lower }}
+                  {{- end }}
+                  key: ca.crt
+            {{- end }}
+            # Identify validation knobs (Spring Boot relaxed-binding to external-authority.identify.*)
+            - name: EXTERNAL_AUTHORITY_IDENTIFY_VERIFY_SIGNATURE
+              value: {{ .Values.identify.verifySignature | quote }}
+            - name: EXTERNAL_AUTHORITY_IDENTIFY_REQUIRE_AUTHORITY_KEY_IDENTIFIER_MATCH
+              value: {{ .Values.identify.requireAuthorityKeyIdentifierMatch | quote }}
+            - name: EXTERNAL_AUTHORITY_IDENTIFY_CHECK_VALIDITY
+              value: {{ .Values.identify.checkValidity | quote }}
+            - name: EXTERNAL_AUTHORITY_IDENTIFY_REQUIRE_CA_BASIC_CONSTRAINT
+              value: {{ .Values.identify.requireCaBasicConstraint | quote }}
+            - name: EXTERNAL_AUTHORITY_IDENTIFY_REQUIRE_KEY_CERT_SIGN_KEY_USAGE
+              value: {{ .Values.identify.requireKeyCertSignKeyUsage | quote }}
+            - name: EXTERNAL_AUTHORITY_IDENTIFY_PKIX
+              value: {{ .Values.identify.pkix | quote }}
+            {{- if $additionalEnv }}
+              {{- $additionalEnv | nindent 12 }}
+            {{- end }}
+          {{- if $additionalEnvFrom }}
+          envFrom:
+            {{- $additionalEnvFrom | indent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          {{- if .Values.image.securityContext }}
+          securityContext: {{- .Values.image.securityContext | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.image.probes.liveness.enabled }}
+          livenessProbe:
+            {{- if .Values.image.probes.liveness.custom }}
+            {{- toYaml .Values.image.probes.liveness.custom | nindent 12 }}
+            {{- else }}
+            httpGet:
+              path: /health/liveness
+              port: {{ .Values.service.port }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.image.probes.liveness.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.image.probes.liveness.timeoutSeconds }}
+            periodSeconds: {{ .Values.image.probes.liveness.periodSeconds }}
+            successThreshold: {{ .Values.image.probes.liveness.successThreshold }}
+            failureThreshold: {{ .Values.image.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.image.probes.readiness.enabled }}
+          readinessProbe:
+            {{- if .Values.image.probes.readiness.custom }}
+            {{- toYaml .Values.image.probes.readiness.custom | nindent 12 }}
+            {{- else }}
+            httpGet:
+              path: /health/readiness
+              port: {{ .Values.service.port }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.image.probes.readiness.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.image.probes.readiness.timeoutSeconds }}
+            periodSeconds: {{ .Values.image.probes.readiness.periodSeconds }}
+            successThreshold: {{ .Values.image.probes.readiness.successThreshold }}
+            failureThreshold: {{ .Values.image.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.image.probes.startup.enabled }}
+          startupProbe:
+            {{- if .Values.image.probes.startup.custom }}
+            {{- toYaml .Values.image.probes.startup.custom | nindent 12 }}
+            {{- else }}
+            httpGet:
+              path: /health/liveness
+              port: {{ .Values.service.port }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.image.probes.startup.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.image.probes.startup.timeoutSeconds }}
+            periodSeconds: {{ .Values.image.probes.startup.periodSeconds }}
+            successThreshold: {{ .Values.image.probes.startup.successThreshold }}
+            failureThreshold: {{ .Values.image.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.image.resources }}
+          resources: {{- toYaml .Values.image.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: ephemeral
+            {{- if $additionalVolumeMounts }}
+              {{- $additionalVolumeMounts | nindent 12 }}
+            {{- end }}
+        {{- if $additionalSidecarContainers }}
+          {{- $additionalSidecarContainers | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: ephemeral
+          {{- include "external-authority-provider.ephemeralVolume" . | indent 10 }}
+        {{- if $additionalVolumes }}
+          {{- $additionalVolumes | nindent 8 }}
+        {{- end }}

--- a/charts/external-authority-provider/templates/external-authority-provider-secret.yaml
+++ b/charts/external-authority-provider/templates/external-authority-provider-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  # if the global values are defined, use it, otherwise use local values
+  password: {{ pluck "password" .Values.global.database .Values.database | compact | first | b64enc | quote }}
+  username: {{ pluck "username" .Values.global.database .Values.database | compact | first | b64enc | quote }}
+kind: Secret
+metadata:
+  name: external-authority-provider-secret

--- a/charts/external-authority-provider/templates/external-authority-provider-service.yaml
+++ b/charts/external-authority-provider/templates/external-authority-provider-service.yaml
@@ -1,0 +1,17 @@
+{{- $additionalPorts := (include "external-authority-provider.customization.ports" $) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-authority-provider-service
+  labels:
+    {{- include "external-authority-provider.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      protocol: "TCP"
+    {{- if $additionalPorts }}
+      {{- $additionalPorts | nindent 4 }}
+    {{- end }}
+  selector:
+    {{- include "external-authority-provider.selectorLabels" . | nindent 4 }}

--- a/charts/external-authority-provider/templates/rbac/service-account.yaml
+++ b/charts/external-authority-provider/templates/rbac/service-account.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "external-authority-provider.serviceAccountName" . }}
+  labels:
+    {{- include "external-authority-provider.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/external-authority-provider/templates/tests/test-connection.yaml
+++ b/charts/external-authority-provider/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "external-authority-provider.fullname" . }}-test-connection"
+  labels:
+    {{- include "external-authority-provider.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: curl
+      image: {{ include "external-authority-provider.curl.image" . }}
+      command:
+        - /bin/sh
+        - -c
+        - |
+          curl --silent --retry 5 --retry-delay 5 --retry-all-errors external-authority-provider-service:{{ .Values.service.port }}/v1
+  restartPolicy: Never

--- a/charts/external-authority-provider/templates/trusted-certificates-secret.yaml
+++ b/charts/external-authority-provider/templates/trusted-certificates-secret.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.trusted.certificates }}
+{{- include "ilm-lib.trusted.certificates.secret.local" (list . "external-authority-provider.trusted.certificates.secret") -}}
+{{- end }}
+
+{{- define "external-authority-provider.trusted.certificates.secret" -}}
+data:
+  ca.crt: {{ required "List of trusted certificates is required: .Values.trusted.certificates!" .Values.trusted.certificates | b64enc }}
+{{- end -}}

--- a/charts/external-authority-provider/values.yaml
+++ b/charts/external-authority-provider/values.yaml
@@ -103,7 +103,7 @@ service:
 image:
   # default registry name
   registry: hub.omnitrustregistry.com
-  repository: ilm
+  repository: ilm-private
   name: external-authority-provider
   tag: 1.0.0
   # the digest to be used instead of the tag

--- a/charts/external-authority-provider/values.yaml
+++ b/charts/external-authority-provider/values.yaml
@@ -1,0 +1,245 @@
+# Default values for external-authority-provider.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: external-authority-provider
+fullnameOverride: ""
+
+# Global parameters that will overwrite local parameters
+global:
+  replicaCount: 1
+  image:
+    registry: ""
+    repository: ""
+    # array of secret names
+    pullSecrets: []
+  volumes:
+    ephemeral:
+      type: ""
+      sizeLimit: ""
+      storageClassName: ""
+      custom: {}
+  database:
+    type: ""
+    host: ""
+    port: ""
+    name: ""
+    username: ""
+    password: ""
+    pgBouncer:
+      enabled: true
+      host: "pg-bouncer-service"
+      port: 5432
+  trusted:
+    certificates: ""
+  httpProxy: ""
+  httpsProxy: ""
+  noProxy: ""
+  # additional init containers that will be added to each pod
+  # - name: some-image
+  #   image: some-image
+  #   imagePullPolicy: IfNotPresent
+  #   securityContext:
+  #     runAsNonRoot: true
+  #   ports:
+  #     - name: port
+  #       containerPort: "{{ $.Values.container.port }}"
+  initContainers: []
+  # additional sidecar containers that will be added to each pod
+  # see the sample of init containers above
+  sidecarContainers: []
+  # additional volumes that will be added to each pod
+  # - name: additional-volume
+  #   configMap:
+  #     name: additional-volume
+  additionalVolumes: []
+  # additional volume mounts that will be added to each pod
+  # - name: additional-volume
+  #   mountPath: /opt/app
+  #   readOnly: true
+  additionalVolumeMounts: []
+  # additional service ports that will be added to each pod
+  # - name: other-port
+  #   port: 8080
+  #   targetPort: 8080
+  additionalPorts: []
+  # additional environment variables that will be added to each pod
+  additionalEnv:
+    # - name: SOME_ENV
+    #   value: "some-value"
+    variables: []
+    # list of config maps to be added as environment variables
+    configMaps: []
+    # list of secrets to be added as environment variables
+    secrets: []
+
+database:
+  # currently only postgresql is supported
+  type: "postgresql"
+  host: "host.docker.internal"
+  port: 5432
+  name: "ilmdb"
+  schema: "externalap"
+  username: "ilmuser"
+  password: "your-strong-password"
+trusted:
+  certificates: ""
+httpProxy: ""
+httpsProxy: ""
+noProxy: ""
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+replicaCount: 1
+
+service:
+  type: "ClusterIP"
+  port: 8080
+
+image:
+  # default registry name
+  registry: hub.omnitrustregistry.com
+  repository: ilm
+  name: external-authority-provider
+  tag: 1.0.0
+  # the digest to be used instead of the tag
+  digest: ""
+  pullPolicy: IfNotPresent
+  # array of secret names
+  pullSecrets: []
+  # custom command and args
+  command: []
+  args: []
+  # default security context
+  securityContext:
+    runAsNonRoot: true
+    # runAsUser: 10001
+    readOnlyRootFilesystem: true
+  # probes configuration
+  probes:
+    liveness:
+      enabled: false
+      # custom probe command, will override the default one
+      custom: {}
+      initialDelaySeconds: 60
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      # custom probe command, will override the default one
+      custom: {}
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+    startup:
+      enabled: true
+      # custom probe command, will override the default one
+      custom: {}
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 45
+  resources: {}
+    # We follow recommendations and general guidelines to manage resources from:
+    # https://master.sdk.operatorframework.io/docs/best-practices/managing-resources/
+    # We recommend default requests for CPU and Memory, leaving the limits as a conscious
+    # choice for the user. If you do want to specify your own resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources'.
+    # requests:
+    #   cpu: 100m
+    #   memory: 400M
+    # limits: {}
+
+curl:
+  image:
+    # default registry name
+    registry: hub.omnitrustregistry.com
+    repository: ilm
+    name: curl
+    tag: 8.16.0
+    # the digest to be used instead of the tag
+    digest: ""
+    pullPolicy: IfNotPresent
+    # array of secret names
+    pullSecrets: []
+    # custom command and args
+    command: []
+    args: []
+    # default security context
+    securityContext:
+      runAsNonRoot: true
+      # runAsUser: 100
+      readOnlyRootFilesystem: true
+    # it does not make sense to have probes for curl
+    resources: {}
+      # We follow recommendations and general guidelines to manage resources from:
+      # https://master.sdk.operatorframework.io/docs/best-practices/managing-resources/
+      # We recommend default requests for CPU and Memory, leaving the limits as a conscious
+      # choice for the user. If you do want to specify your own resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources'.
+      # requests:
+      #   cpu: 50m
+      #   memory: 150M
+      # limits: {}
+
+# customization of the chart
+initContainers: []
+sidecarContainers: []
+additionalVolumes: []
+additionalVolumeMounts: []
+additionalPorts: []
+additionalEnv:
+  variables: []
+  configMaps: []
+  secrets: []
+
+volumes:
+  ephemeral:
+    # available types are: memory, storage, custom
+    type: memory
+    sizeLimit: "1Mi"
+    storageClassName: ""
+    custom: {}
+    #  emptyDir:
+    #    sizeLimit: "10Mi"
+    #    medium: "Memory"
+
+logging:
+  level: "INFO"
+
+# Identify validation knobs.
+# Per-property semantics live in the connector's IdentifyValidationProperties
+# (com.otilm.ca.connector.external.config). Defaults match the connector's
+# shipping defaults — signature-only validation.
+identify:
+  verifySignature: true
+  requireAuthorityKeyIdentifierMatch: false
+  checkValidity: false
+  requireCaBasicConstraint: false
+  requireKeyCertSignKeyUsage: false
+  pkix: false
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "external-authority-provider-sa"
+
+podLabels: {}
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000

--- a/charts/ilm/Chart.lock
+++ b/charts/ilm/Chart.lock
@@ -8,6 +8,9 @@ dependencies:
 - name: ejbca-ng-connector
   repository: file://../ejbca-ng-connector
   version: 1.11.1-3-develop
+- name: external-authority-provider
+  repository: file://../external-authority-provider
+  version: 1.0.0-develop
 - name: pyadcs-connector
   repository: file://../pyadcs-connector
   version: 1.1.6-1-develop
@@ -68,5 +71,5 @@ dependencies:
 - name: pg-bouncer
   repository: file://../pg-bouncer
   version: 1.24.1-p1-2-develop
-digest: sha256:413f4d0a9a19c3d44d9c439dabd592c2ff88c112cae2bfbae909e121276dabbe
-generated: "2026-04-25T10:39:25.145926+02:00"
+digest: sha256:6dc75d8686ac53db3a0e3160506146ccc31720c17993381212387c4c49fced21
+generated: "2026-05-10T10:31:06.223705+02:00"

--- a/charts/ilm/Chart.yaml
+++ b/charts/ilm/Chart.yaml
@@ -32,6 +32,14 @@ dependencies:
       - discovery-provider
     version: 1.11.1-3-develop
     alias: ejbcaNgConnector
+  - condition: externalAuthorityProvider.enabled
+    name: external-authority-provider
+    # repository: oci://hub.omnitrustregistry.com/ilm-helm
+    repository: file://../external-authority-provider
+    tags:
+      - authority-provider
+    version: 1.0.0-develop
+    alias: externalAuthorityProvider
   - condition: pyAdcsConnector.enabled
     name: pyadcs-connector
     # repository: oci://hub.omnitrustregistry.com/ilm-helm

--- a/charts/ilm/templates/hooks/register-connectors-job.yaml
+++ b/charts/ilm/templates/hooks/register-connectors-job.yaml
@@ -49,6 +49,11 @@ spec:
             -d '{"name": "EJBCA-NG-Connector","url": "http://ejbca-ng-connector-service:{{ .Values.ejbcaNgConnector.service.port }}","authType": "none"}' \
             http://core-service:{{ .Values.service.port }}/api/v1/connector/register &&
             {{- end }}
+            {{- if .Values.externalAuthorityProvider.enabled }}
+            curl -X POST -k -H 'content-type: application/json' \
+            -d '{"name": "External-Authority-Provider","url": "http://external-authority-provider-service:{{ .Values.externalAuthorityProvider.service.port }}","authType": "none"}' \
+            http://core-service:{{ .Values.service.port }}/api/v1/connector/register &&
+            {{- end }}
             {{- if .Values.cryptosenseDiscoveryProvider.enabled }}
             curl -X POST -k -H 'content-type: application/json' \
             -d '{"name": "Cryptosense-Discovery-Provider","url": "http://cryptosense-discovery-provider-service:{{ .Values.cryptosenseDiscoveryProvider.service.port }}","authType": "none"}' \

--- a/charts/ilm/values.yaml
+++ b/charts/ilm/values.yaml
@@ -563,6 +563,10 @@ ejbcaNgConnector:
   nameOverride: ejbca-ng-connector
   enabled: false
 
+externalAuthorityProvider:
+  nameOverride: external-authority-provider
+  enabled: false
+
 pyAdcsConnector:
   nameOverride: pyadcs-connector
   enabled: false

--- a/update-all-dependencies.sh
+++ b/update-all-dependencies.sh
@@ -30,6 +30,9 @@ helm dependency update charts/ejbca-ng-connector --skip-refresh
 echo "Updating dependencies for email-notification-provider..."
 helm dependency update charts/email-notification-provider --skip-refresh
 
+echo "Updating dependencies for external-authority-provider..."
+helm dependency update charts/external-authority-provider --skip-refresh
+
 echo "Updating dependencies for fe-administrator..."
 helm dependency update charts/fe-administrator --skip-refresh
 


### PR DESCRIPTION
## Summary

Adds the External Authority Provider Helm chart and wires it into the \`ilm\` umbrella as an optional dependency.

## What changed

- New chart \`charts/external-authority-provider\` (\`1.0.0-develop\`), modelled on \`ejbca-ng-connector\`. Standard Spring Boot connector wiring: \`PORT\`, \`JDBC_URL\` (with \`characterEncoding=UTF-8\`), \`JDBC_USERNAME\` / \`JDBC_PASSWORD\` from a generated Secret, \`DB_SCHEMA\` (default \`externalap\`), \`LOGGING_LEVEL_COM_CZERTAINLY\` and \`LOGGING_LEVEL_COM_OTILM\`, optional \`TRUSTED_CERTIFICATES\`, ephemeral volume, ServiceAccount, and a \`/v1\` test-connection probe.
- Identify-validation knobs from the connector's \`IdentifyValidationProperties\` exposed as env vars (Spring relaxed-binding to \`external-authority.identify.*\`): \`EXTERNAL_AUTHORITY_IDENTIFY_VERIFY_SIGNATURE\`, \`...REQUIRE_AUTHORITY_KEY_IDENTIFIER_MATCH\`, \`...CHECK_VALIDITY\`, \`...REQUIRE_CA_BASIC_CONSTRAINT\`, \`...REQUIRE_KEY_CERT_SIGN_KEY_USAGE\`, \`...PKIX\`. Defaults match the connector's shipping defaults (signature-only).
- \`charts/ilm\` umbrella: optional dependency with condition \`externalAuthorityProvider.enabled\` (default \`false\`), tagged \`authority-provider\`.
- Post-install registration hook calls \`/api/v1/connector/register\` for \`External-Authority-Provider\` when the toggle is on.
- \`update-all-dependencies.sh\` updated with the new chart in alphabetical order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)