### PR TITLE
external-authority-provider: drop identify env vars

### DIFF
--- a/charts/external-authority-provider/README.md
+++ b/charts/external-authority-provider/README.md
@@ -145,19 +145,6 @@ The following values may be configured:
 | serviceAccount.annotations                   | `{}`                               | Annotations to add to the service account                                                                                   |
 | serviceAccount.name                          | `"external-authority-provider-sa"` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template      |
 
-#### Identify validation parameters
-
-The connector exposes a set of boolean knobs that control how `identifyCertificate` validates a certificate against the configured CA chain. Per-property semantics live in the connector's `IdentifyValidationProperties` (`com.otilm.ca.connector.external.config`); defaults match the connector's shipping behaviour (signature-only validation).
-
-| Parameter                                   | Default value | Description                                                                                       |
-|---------------------------------------------|---------------|---------------------------------------------------------------------------------------------------|
-| identify.verifySignature                    | `true`        | Verify the input certificate's signature under the configured CA's key                            |
-| identify.requireAuthorityKeyIdentifierMatch | `false`       | Require the input cert's AKI to match a configured CA's SKI                                       |
-| identify.checkValidity                      | `false`       | Require both the input cert and the matching CA cert to be currently valid                        |
-| identify.requireCaBasicConstraint           | `false`       | Require the matching CA cert's BasicConstraints `cA = true`                                       |
-| identify.requireKeyCertSignKeyUsage         | `false`       | Require the matching CA cert's KeyUsage to include `keyCertSign`                                  |
-| identify.pkix                               | `false`       | Run the JDK's full PKIX path validation (RFC 5280); takes precedence over individual flags above  |
-
 #### Customization parameters
 
 | Parameter                | Default value | Description                        |

--- a/charts/external-authority-provider/templates/external-authority-provider-deployment.yaml
+++ b/charts/external-authority-provider/templates/external-authority-provider-deployment.yaml
@@ -101,19 +101,6 @@ spec:
                   {{- end }}
                   key: ca.crt
             {{- end }}
-            # Identify validation knobs (Spring Boot relaxed-binding to external-authority.identify.*)
-            - name: EXTERNAL_AUTHORITY_IDENTIFY_VERIFY_SIGNATURE
-              value: {{ .Values.identify.verifySignature | quote }}
-            - name: EXTERNAL_AUTHORITY_IDENTIFY_REQUIRE_AUTHORITY_KEY_IDENTIFIER_MATCH
-              value: {{ .Values.identify.requireAuthorityKeyIdentifierMatch | quote }}
-            - name: EXTERNAL_AUTHORITY_IDENTIFY_CHECK_VALIDITY
-              value: {{ .Values.identify.checkValidity | quote }}
-            - name: EXTERNAL_AUTHORITY_IDENTIFY_REQUIRE_CA_BASIC_CONSTRAINT
-              value: {{ .Values.identify.requireCaBasicConstraint | quote }}
-            - name: EXTERNAL_AUTHORITY_IDENTIFY_REQUIRE_KEY_CERT_SIGN_KEY_USAGE
-              value: {{ .Values.identify.requireKeyCertSignKeyUsage | quote }}
-            - name: EXTERNAL_AUTHORITY_IDENTIFY_PKIX
-              value: {{ .Values.identify.pkix | quote }}
             {{- if $additionalEnv }}
               {{- $additionalEnv | nindent 12 }}
             {{- end }}

--- a/charts/external-authority-provider/values.yaml
+++ b/charts/external-authority-provider/values.yaml
@@ -216,18 +216,6 @@ volumes:
 logging:
   level: "INFO"
 
-# Identify validation knobs.
-# Per-property semantics live in the connector's IdentifyValidationProperties
-# (com.otilm.ca.connector.external.config). Defaults match the connector's
-# shipping defaults — signature-only validation.
-identify:
-  verifySignature: true
-  requireAuthorityKeyIdentifierMatch: false
-  checkValidity: false
-  requireCaBasicConstraint: false
-  requireKeyCertSignKeyUsage: false
-  pkix: false
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
## Summary

The identify validation knobs (\`verifySignature\`, \`requireAuthorityKeyIdentifierMatch\`, \`checkValidity\`, \`requireCaBasicConstraint\`, \`requireKeyCertSignKeyUsage\`, \`pkix\`) are now per-Authority attributes on the connector side (OmniTrustILM/external-authority-provider#5). They are no longer configured via Spring properties, so the chart no longer needs to expose them as env vars.

## What changed

- Removed the six \`EXTERNAL_AUTHORITY_IDENTIFY_*\` env vars from the Deployment template.
- Removed the \`identify.*\` block from \`values.yaml\`.
- Removed the *Identify validation parameters* section from the chart README.

## Sequencing

Merge order: the connector PR (OmniTrustILM/external-authority-provider#5) lands first and publishes a new image; the new chart is built from that image and no longer carries the now-unused env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)