### PR TITLE
Remove duplicate helm.sh/chart label in ILM hook jobs

### DIFF
--- a/charts/ilm/templates/hooks/register-admin-job.yaml
+++ b/charts/ilm/templates/hooks/register-admin-job.yaml
@@ -6,7 +6,6 @@ metadata:
   name: "{{ .Release.Name }}-{{ $jobName }}"
   labels:
     {{- include "ilm.labels" . | nindent 4 }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.

--- a/charts/ilm/templates/hooks/register-connectors-job.yaml
+++ b/charts/ilm/templates/hooks/register-connectors-job.yaml
@@ -6,7 +6,6 @@ metadata:
   name: "{{ .Release.Name }}-{{ $jobName }}"
   labels:
     {{- include "ilm.labels" . | nindent 4 }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.


### PR DESCRIPTION
## Summary
- The `ilm.labels` helper already emits `helm.sh/chart`, but `register-admin-job.yaml` and `register-connectors-job.yaml` re-added the same key on the next line, producing a duplicate key in `metadata.labels`.
- Helm tolerates duplicate map keys (last write wins), but kustomize in strict mode rejects the rendered manifest.
- Removed the redundant explicit `helm.sh/chart` line in both hook templates so the helper is the single source of truth.

## Test plan
- [x] `helm template charts/ilm --set registerAdmin.enabled=true --set registerAdmin.source=generated --set registerConnectors=true` renders both Jobs with exactly one `helm.sh/chart` label.
- [x] Scanned the umbrella chart with every subchart enabled (120 rendered resources) and each standalone chart — no duplicate keys in any `labels:` block.
- [x] `helm lint charts/ilm` passes.