### PR TITLE
Rename messaging vhost to '/' and exchanges to ilm

### DIFF
--- a/charts/ilm/Chart.lock
+++ b/charts/ilm/Chart.lock
@@ -71,5 +71,5 @@ dependencies:
 - name: pg-bouncer
   repository: file://../pg-bouncer
   version: 1.24.1-p1-2
-digest: sha256:e402472c1f62ef929f8bde594602e59533f85be34cbe758e0c8fe9c741b32e47
-generated: "2026-06-06T14:49:03.436883+02:00"
+digest: sha256:3951a610395d2da828563a5f15e08ff275ae75efbcb3216da2073c6158d15bc2
+generated: "2026-06-16T09:13:52.328574+02:00"

--- a/charts/ilm/Chart.lock
+++ b/charts/ilm/Chart.lock
@@ -61,13 +61,13 @@ dependencies:
   version: 1.4.1-2
 - name: messaging-rabbitmq
   repository: file://../messaging-rabbitmq
-  version: 4.2.0-2
+  version: 4.2.0-2-develop
 - name: scheduler-service
   repository: file://../scheduler-service
-  version: 1.1.0
+  version: 1.1.1-develop
 - name: provisioning-rabbitmq
   repository: file://../provisioning-rabbitmq
-  version: 1.0.0
+  version: 1.0.0-develop
 - name: pg-bouncer
   repository: file://../pg-bouncer
   version: 1.24.1-p1-2

--- a/charts/ilm/Chart.lock
+++ b/charts/ilm/Chart.lock
@@ -61,15 +61,15 @@ dependencies:
   version: 1.4.1-2
 - name: messaging-rabbitmq
   repository: file://../messaging-rabbitmq
-  version: 4.2.0-2-develop
+  version: 4.2.0-3-develop
 - name: scheduler-service
   repository: file://../scheduler-service
   version: 1.1.1-develop
 - name: provisioning-rabbitmq
   repository: file://../provisioning-rabbitmq
-  version: 1.0.0-develop
+  version: 1.0.0-1-develop
 - name: pg-bouncer
   repository: file://../pg-bouncer
   version: 1.24.1-p1-2
-digest: sha256:3951a610395d2da828563a5f15e08ff275ae75efbcb3216da2073c6158d15bc2
-generated: "2026-06-16T09:13:52.328574+02:00"
+digest: sha256:fb9a26001a458be007c8dbe75e5a7817ce1cf8a76f6b12b807680abf65cf8250
+generated: "2026-06-16T11:40:55.605634+02:00"

--- a/charts/ilm/Chart.yaml
+++ b/charts/ilm/Chart.yaml
@@ -170,14 +170,14 @@ dependencies:
     repository: file://../messaging-rabbitmq
     tags:
       - messaging
-    version: 4.2.0-2
+    version: 4.2.0-2-develop
     alias: messagingService
   - name: scheduler-service
     # repository: oci://hub.omnitrustregistry.com/ilm-helm
     repository: file://../scheduler-service
     tags:
       - scheduler
-    version: 1.1.0
+    version: 1.1.1-develop
     alias: schedulerService
   - condition: provisioningRabbitMq.enabled
     name: provisioning-rabbitmq
@@ -185,7 +185,7 @@ dependencies:
     repository: file://../provisioning-rabbitmq
     tags:
       - provisioning-rabbitmq
-    version: 1.0.0
+    version: 1.0.0-develop
     alias: provisioningRabbitMq
   - condition: global.database.pgBouncer.enabled
     name: pg-bouncer

--- a/charts/ilm/Chart.yaml
+++ b/charts/ilm/Chart.yaml
@@ -170,7 +170,7 @@ dependencies:
     repository: file://../messaging-rabbitmq
     tags:
       - messaging
-    version: 4.2.0-2-develop
+    version: 4.2.0-3-develop
     alias: messagingService
   - name: scheduler-service
     # repository: oci://hub.omnitrustregistry.com/ilm-helm
@@ -185,7 +185,7 @@ dependencies:
     repository: file://../provisioning-rabbitmq
     tags:
       - provisioning-rabbitmq
-    version: 1.0.0-develop
+    version: 1.0.0-1-develop
     alias: provisioningRabbitMq
   - condition: global.database.pgBouncer.enabled
     name: pg-bouncer

--- a/charts/ilm/Chart.yaml
+++ b/charts/ilm/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: trustLifecycleManagement
 apiVersion: v2
-appVersion: 2.18.0
+appVersion: 2.18.1-develop
 name: ilm
 description: A Helm chart for ILM platform.
 home: https://github.com/OmniTrustILM/ilm
@@ -212,4 +212,4 @@ sources:
   - https://github.com/OmniTrustILM/ilm
   - https://omnitrust.com
   - https://docs.otilm.com
-version: 2.18.0
+version: 2.18.1-develop

--- a/charts/ilm/docs/upgrading.md
+++ b/charts/ilm/docs/upgrading.md
@@ -14,6 +14,35 @@ The following contains important information and instructions about upgrading He
 
 Upgrading Helm chart is done by running the `helm upgrade` command. The command upgrades the platform to the specified version. The command can be used to upgrade the platform to the same version with changed parameters.
 
+## To 2.19.0
+
+### RabbitMQ virtual host and exchange rename
+
+The default RabbitMQ virtual host has changed from `czertainly` to `/` (the RabbitMQ default), and the exchange names have changed from `czertainly`/`czertainly-proxy` to `ilm`/`ilm-proxy`.
+
+| Parameter                  | Old default        | New default |
+|----------------------------|--------------------|-------------|
+| `messaging.virtualHost`    | `czertainly`       | `/`         |
+| `bootstrap.exchange`       | `czertainly`       | `ilm`       |
+| `bootstrap.proxy.exchange` | `czertainly-proxy` | `ilm-proxy` |
+
+#### Fresh installation
+
+No manual steps are required. The new virtual host and exchanges are created automatically by `provisioning-rabbitmq` on first startup.
+
+#### Upgrade from a previous version
+
+After `helm upgrade`, `provisioning-rabbitmq` will create the new exchanges and queues on the `/` vhost automatically. The old `czertainly` vhost and its queues remain in RabbitMQ untouched — they are orphaned but not deleted.
+
+**What to do with the old `czertainly` vhost:**
+
+| Situation                                    | Action                                                                                                                                                                                         |
+|----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| No messages in queues / messages can be lost | Delete the `czertainly` vhost from the RabbitMQ management UI after confirming the upgrade is stable.                                                                                          |
+| Messages must be preserved                   | Before upgrading, drain all queues on the `czertainly` vhost (wait for consumers to process all messages). Then upgrade.                                                                       |
+| You cannot migrate yet                       | Override `messaging.virtualHost` back to `czertainly` and exchange names back to `czertainly`/`czertainly-proxy` in your values to keep using the old topology until you are ready to migrate. |
+
+
 ## To 2.18.0
 
 This release rebrands the Helm charts from CZERTAINLY to ILM (OmniTrust ILM). The umbrella chart was renamed from `czertainly` to `ilm`, and the library chart from `czertainly-lib` to `ilm-lib`. Container images, registry, database defaults, Keycloak realm, and project URLs were all updated.

--- a/charts/ilm/docs/upgrading.md
+++ b/charts/ilm/docs/upgrading.md
@@ -39,8 +39,52 @@ After `helm upgrade`, `provisioning-rabbitmq` will create the new exchanges and 
 | Situation                                    | Action                                                                                                                                                                                         |
 |----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | No messages in queues / messages can be lost | Delete the `czertainly` vhost from the RabbitMQ management UI after confirming the upgrade is stable.                                                                                          |
-| Messages must be preserved                   | Before upgrading, drain all queues on the `czertainly` vhost (wait for consumers to process all messages). Then upgrade.                                                                       |
+| Messages must be preserved                   | Follow the drain procedure below before upgrading.                                                                                                                                             |
 | You cannot migrate yet                       | Override `messaging.virtualHost` back to `czertainly` and exchange names back to `czertainly`/`czertainly-proxy` in your values to keep using the old topology until you are ready to migrate. |
+
+##### Drain procedure
+
+Stop new messages from entering the system by scaling down the API gateway:
+
+```bash
+kubectl scale deployment api-gateway-deployment --replicas=0 --namespace <your-namespace>
+```
+
+Then wait for critical queues to drain using the following script (adjust `RABBIT_HOST`, `AUTH`, and `QUEUES` to match your environment):
+
+```bash
+#!/bin/bash
+RABBIT_HOST="localhost"
+RABBIT_PORT="15672"
+AUTH="admin:admin"
+VHOST="czertainly"
+QUEUES=("core.audit-logs")
+
+echo "Waiting for queues to drain on vhost '$VHOST'..."
+
+while true; do
+  TOTAL=0
+  for QUEUE in "${QUEUES[@]}"; do
+    COUNT=$(curl -s -u "$AUTH" \
+      "http://$RABBIT_HOST:$RABBIT_PORT/api/queues/$(printf '%s' "$VHOST" | sed 's|/|%2F|g')/$QUEUE" \
+      | grep -o '"messages":[0-9]*' | head -1 | cut -d: -f2)
+    COUNT=${COUNT:-0}
+    echo "  $QUEUE: $COUNT messages"
+    TOTAL=$((TOTAL + COUNT))
+  done
+
+  echo "Total remaining: $TOTAL"
+
+  if [ "$TOTAL" -eq 0 ]; then
+    echo "All queues drained. Safe to upgrade."
+    exit 0
+  fi
+
+  sleep 5
+done
+```
+
+Once the script exits, run `helm upgrade` as usual. The API gateway will be restored automatically as part of the upgrade.
 
 
 ## To 2.18.0

--- a/charts/ilm/templates/_helpers.tpl
+++ b/charts/ilm/templates/_helpers.tpl
@@ -252,7 +252,7 @@ Calls POST /api/v1/queues on the provisioning API with retry loop.
             -H "X-API-Key: ${PROVISIONING_API_KEY}" \
             -d "{
               \"name\": \"${HOSTNAME}\",
-              \"exchange\": \"czertainly-proxy\",
+              \"exchange\": \"ilm-proxy\",
               \"routingKey\": \"proxymessage.*.${HOSTNAME}\",
               \"properties\": { \"x-expires\": 1800000 }
             }"
@@ -261,7 +261,7 @@ Calls POST /api/v1/queues on the provisioning API with retry loop.
             -H "Content-Type: application/json" \
             -d "{
               \"name\": \"${HOSTNAME}\",
-              \"exchange\": \"czertainly-proxy\",
+              \"exchange\": \"ilm-proxy\",
               \"routingKey\": \"proxymessage.*.${HOSTNAME}\",
               \"properties\": { \"x-expires\": 1800000 }
             }"

--- a/charts/ilm/templates/core-deployment.yaml
+++ b/charts/ilm/templates/core-deployment.yaml
@@ -202,7 +202,7 @@ spec:
                 secretKeyRef:
                   name: core-secret
                   key: jdbcPassword
-            - name: LOGGING_LEVEL_COM_CZERTAINLY
+            - name: LOGGING_LEVEL_COM_OTILM
               value: {{ .Values.logging.level | quote }}
             {{- if .Values.registerAdmin.enabled }}
             - name: ADMIN_CERT
@@ -245,7 +245,7 @@ spec:
                   name: messaging-secret
                   key: messaging.core.password
             - name: BROKER_VIRTUAL_HOST
-              value: {{ pluck "virtualHost" .Values.global.messaging .Values.messaging | compact | first | default "czertainly" | quote }}
+              value: {{ pluck "virtualHost" .Values.global.messaging .Values.messaging | compact | first | default "/" | quote }}
             - name: SCHEDULER_BASE_URL
               value: "http://scheduler-service-service:{{ .Values.schedulerService.service.port }}"
             {{- if .Values.global.keycloak.enabled }}

--- a/charts/ilm/values.yaml
+++ b/charts/ilm/values.yaml
@@ -432,7 +432,7 @@ messaging:
   host: "messaging-service"
   amqp:
     port: 5672
-  virtualHost: "czertainly"
+  virtualHost: "/"
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/messaging-rabbitmq/Chart.yaml
+++ b/charts/messaging-rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: trustLifecycleManagement
 apiVersion: v2
-appVersion: 4.2.0
+appVersion: 4.2.0-develop
 name: messaging-rabbitmq
 description: A Helm chart for RabbitMQ messaging for ILM platform.
 home: https://github.com/OmniTrustILM/ilm
@@ -28,4 +28,4 @@ sources:
   - https://github.com/OmniTrustILM/ilm
   - https://omnitrust.com
   - https://docs.otilm.com
-version: 4.2.0-2
+version: 4.2.0-2-develop

--- a/charts/messaging-rabbitmq/Chart.yaml
+++ b/charts/messaging-rabbitmq/Chart.yaml
@@ -28,4 +28,4 @@ sources:
   - https://github.com/OmniTrustILM/ilm
   - https://omnitrust.com
   - https://docs.otilm.com
-version: 4.2.0-2-develop
+version: 4.2.0-3-develop

--- a/charts/messaging-rabbitmq/templates/_definitions_json.tpl
+++ b/charts/messaging-rabbitmq/templates/_definitions_json.tpl
@@ -19,7 +19,7 @@ Example:
 {{- $corePassword               := pluck "corePassword"               .global.messaging .messagingService.messaging | compact | first }}
 {{- $timeQualityMonitorUsername := pluck "timeQualityMonitorUsername" .global.messaging .messagingService.messaging | compact | first }}
 {{- $timeQualityMonitorPassword := pluck "timeQualityMonitorPassword" .global.messaging .messagingService.messaging | compact | first }}
-{{- $virtualHost                := pluck "virtualHost"                .global.messaging .messagingService.messaging | compact | first | default "czertainly" }}
+{{- $virtualHost                := pluck "virtualHost"                .global.messaging .messagingService.messaging | compact | first | default "/" }}
 {
   "users": [
     {
@@ -78,27 +78,27 @@ Example:
       "user": "{{ $proxyUsername }}",
       "vhost": "{{ $virtualHost }}",
       "configure": "",
-      "write": "^czertainly-proxy$",
+      "write": "^ilm-proxy$",
       "read": "^proxy\\..*$"
     },
     {
       "user": "{{ $coreUsername }}",
       "vhost": "{{ $virtualHost }}",
       "configure": "",
-      "write": "^czertainly(-proxy)?$",
+      "write": "^ilm(-proxy)?$",
       "read": "^core(\\..+|-.+)?$|^time-quality\\.(config-request|results)$"
     },
     {
       "user": "{{ $timeQualityMonitorUsername }}",
       "vhost": "{{ $virtualHost }}",
       "configure": "",
-      "write": "^czertainly$",
+      "write": "^ilm$",
       "read": "^time-quality\\.config$"
     }
   ],
   "exchanges": [
     {
-      "name": "czertainly",
+      "name": "ilm",
       "vhost": "{{ $virtualHost }}",
       "type": "direct",
       "durable": true,
@@ -107,7 +107,7 @@ Example:
       "arguments": {}
     },
     {
-      "name": "czertainly-proxy",
+      "name": "ilm-proxy",
       "vhost": "{{ $virtualHost }}",
       "type": "topic",
       "durable": true,
@@ -196,7 +196,7 @@ Example:
   ],
   "bindings": [
     {
-      "source": "czertainly",
+      "source": "ilm",
       "vhost": "{{ $virtualHost }}",
       "destination": "core.audit-logs",
       "destination_type": "queue",
@@ -204,7 +204,7 @@ Example:
       "arguments": {}
     },
     {
-      "source": "czertainly",
+      "source": "ilm",
       "vhost": "{{ $virtualHost }}",
       "destination": "core.notifications",
       "destination_type": "queue",
@@ -212,7 +212,7 @@ Example:
       "arguments": {}
     },
     {
-      "source": "czertainly",
+      "source": "ilm",
       "vhost": "{{ $virtualHost }}",
       "destination": "core.actions",
       "destination_type": "queue",
@@ -220,7 +220,7 @@ Example:
       "arguments": {}
     },
     {
-      "source": "czertainly",
+      "source": "ilm",
       "vhost": "{{ $virtualHost }}",
       "destination": "core.scheduler",
       "destination_type": "queue",
@@ -228,7 +228,7 @@ Example:
       "arguments": {}
     },
     {
-      "source": "czertainly",
+      "source": "ilm",
       "vhost": "{{ $virtualHost }}",
       "destination": "core.validation",
       "destination_type": "queue",
@@ -236,7 +236,7 @@ Example:
       "arguments": {}
     },
     {
-      "source": "czertainly",
+      "source": "ilm",
       "vhost": "{{ $virtualHost }}",
       "destination": "core.events",
       "destination_type": "queue",
@@ -244,7 +244,7 @@ Example:
       "arguments": {}
     },
     {
-      "source": "czertainly",
+      "source": "ilm",
       "vhost": "{{ $virtualHost }}",
       "destination": "time-quality.config",
       "destination_type": "queue",
@@ -252,7 +252,7 @@ Example:
       "arguments": {}
     },
     {
-      "source": "czertainly",
+      "source": "ilm",
       "vhost": "{{ $virtualHost }}",
       "destination": "time-quality.config-request",
       "destination_type": "queue",
@@ -260,7 +260,7 @@ Example:
       "arguments": {}
     },
     {
-      "source": "czertainly",
+      "source": "ilm",
       "vhost": "{{ $virtualHost }}",
       "destination": "time-quality.results",
       "destination_type": "queue",

--- a/charts/messaging-rabbitmq/values.yaml
+++ b/charts/messaging-rabbitmq/values.yaml
@@ -259,7 +259,7 @@ messaging:
   corePassword: "core"
   timeQualityMonitorUsername: "time-quality-monitor"
   timeQualityMonitorPassword: "time-quality-monitor"
-  virtualHost: "czertainly"
+  virtualHost: "/"
   erlang:
     cookie: "c4eGHK4gM3v+5BHTFkGaRzqNQu0JcokVJkFK7CmJ"
   plugins:

--- a/charts/provisioning-rabbitmq/Chart.lock
+++ b/charts/provisioning-rabbitmq/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.4.2-1
 - name: messaging-rabbitmq
   repository: file://../messaging-rabbitmq
-  version: 4.2.0-2-develop
-digest: sha256:a4576508e1beb9466abe899b9c9f320bf712cad0b82cb4bb23718648ae7d7f32
-generated: "2026-06-16T09:33:15.549673+02:00"
+  version: 4.2.0-3-develop
+digest: sha256:fa0470cf1e865502e106f718c46e8549c905d4e14dc1aa867d7c1e64b8e7e4a5
+generated: "2026-06-16T11:48:18.808985+02:00"

--- a/charts/provisioning-rabbitmq/Chart.lock
+++ b/charts/provisioning-rabbitmq/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.4.2-1
 - name: messaging-rabbitmq
   repository: file://../messaging-rabbitmq
-  version: 4.2.0-2
+  version: 4.2.0-2-develop
 digest: sha256:ef847c6eb4654184fa1d8ba95981096f221e70759e1642341791ccb66ff0cc11
 generated: "2026-06-06T14:49:02.307619+02:00"

--- a/charts/provisioning-rabbitmq/Chart.lock
+++ b/charts/provisioning-rabbitmq/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: messaging-rabbitmq
   repository: file://../messaging-rabbitmq
   version: 4.2.0-2-develop
-digest: sha256:ef847c6eb4654184fa1d8ba95981096f221e70759e1642341791ccb66ff0cc11
-generated: "2026-06-06T14:49:02.307619+02:00"
+digest: sha256:a4576508e1beb9466abe899b9c9f320bf712cad0b82cb4bb23718648ae7d7f32
+generated: "2026-06-16T09:33:15.549673+02:00"

--- a/charts/provisioning-rabbitmq/Chart.yaml
+++ b/charts/provisioning-rabbitmq/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
     repository: file://../messaging-rabbitmq
     tags:
       - messaging
-    version: 4.2.0-2-develop
+    version: 4.2.0-3-develop
     condition: messaging.local
 keywords:
   - ilm
@@ -35,4 +35,4 @@ sources:
   - https://github.com/OmniTrustILM/ilm
   - https://omnitrust.com
   - https://docs.otilm.com
-version: 1.0.0-develop
+version: 1.0.0-1-develop

--- a/charts/provisioning-rabbitmq/Chart.yaml
+++ b/charts/provisioning-rabbitmq/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
     repository: file://../messaging-rabbitmq
     tags:
       - messaging
-    version: 4.2.0-2
+    version: 4.2.0-2-develop
     condition: messaging.local
 keywords:
   - ilm

--- a/charts/provisioning-rabbitmq/Chart.yaml
+++ b/charts/provisioning-rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: trustLifecycleManagement
 apiVersion: v2
-appVersion: 1.0.0
+appVersion: 1.0.0-develop
 name: provisioning-rabbitmq
 description: A Helm chart for RabbitMQ provisioning service for ILM platform.
 home: https://github.com/OmniTrustILM/ilm
@@ -35,4 +35,4 @@ sources:
   - https://github.com/OmniTrustILM/ilm
   - https://omnitrust.com
   - https://docs.otilm.com
-version: 1.0.0
+version: 1.0.0-develop

--- a/charts/provisioning-rabbitmq/README.md
+++ b/charts/provisioning-rabbitmq/README.md
@@ -101,52 +101,52 @@ Global values are used to define common parameters for the chart and all its sub
 
 The following values may be configured:
 
-| Parameter                                    | Default value                        | Description                                                                                                              |
-|----------------------------------------------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| nameOverride                                 | `provisioning-rabbitmq`              | Override for the chart name. Used as the `app.kubernetes.io/name` selector label value and as input to the fullname helper. Pinned to keep selectors stable across chart renames; changing this requires manual cleanup of existing Deployments. |
-| fullnameOverride                             | `""`                                 | Override for the fully qualified app name.                                                                               |
-| image.registry                               | `hub.omnitrustregistry.com`          | Docker registry name for the image                                                                                       |
-| image.repository                             | `ilm`                                | Docker image repository name                                                                                             |
-| image.name                                   | `provisioning-rabbitmq`              | Docker image name                                                                                                        |
-| image.tag                                    | `1.0.0`                              | Docker image tag                                                                                                         |
-| image.digest                                 | `""`                                 | Docker image digest, will override tag if specified                                                                      |
-| image.pullPolicy                             | `IfNotPresent`                       | Image pull policy                                                                                                        |
-| image.pullSecrets                            | `[]`                                 | Array of secret names for image pull                                                                                     |
-| image.command                                | `[]`                                 | Override the default command                                                                                             |
-| image.args                                   | `[]`                                 | Override the default args                                                                                                |
-| image.securityContext.runAsNonRoot           | `true`                               | Run the container as non-root user                                                                                       |
-| image.securityContext.readOnlyRootFilesystem | `true`                               | Run the container with read-only root filesystem                                                                         |
-| image.resources                              | `{}`                                 | The resources for the container                                                                                          |
-| podLabels                                    | `{}`                                 | Labels to be added to the pod                                                                                            |
-| podAnnotations                               | `{}`                                 | Annotations to be added to the pod                                                                                       |
-| podSecurityContext                           | `{}`                                 | Pod security context                                                                                                     |
-| volumes.ephemeral.type                       | `memory`                             | Ephemeral volume type to be used                                                                                         |
-| volumes.ephemeral.sizeLimit                  | `"1Mi"`                              | Ephemeral volume size limit                                                                                              |
-| volumes.ephemeral.storageClassName           | `""`                                 | Ephemeral volume storage class name for `storage` type                                                                   |
-| volumes.ephemeral.custom                     | `{}`                                 | Custom definition of the ephemeral volume for `custom` type                                                              |
-| logging.level                                | `"INFO"`                             | Allowed values are `"INFO"`, `"DEBUG"`, `"WARN"`, `"TRACE"`                                                             |
-| service.type                                 | `"ClusterIP"`                        | Type of the service that is exposed                                                                                      |
-| service.port                                 | `8077`                               | Port number of the exposed service                                                                                       |
-| javaOpts                                     | `""`                                 | Customize Java system properties                                                                                         |
-| messaging.external.enabled                   | `false`                              | Enable external messaging                                                                                                |
-| messaging.external.host                      | `""`                                 | Host where the external messaging is located                                                                             |
-| messaging.external.amqp.port                 | `""`                                 | Port on which the external messaging is listening                                                                        |
-| messaging.provisionerUsername                | `"provisioner"`                      | Admin/provisioner username for managing RabbitMQ queues and exchanges                                                    |
-| messaging.provisionerPassword                | `"provisioner"`                      | Admin/provisioner password for managing RabbitMQ queues and exchanges                                                    |
-| messaging.proxyUsername                      | `"proxy"`                            | Proxy user credentials included in generated JWT tokens for proxy services                                               |
-| messaging.proxyPassword                      | `"proxy"`                            | Proxy user password included in generated JWT tokens for proxy services                                                  |
-| messaging.host                               | `"messaging-service"`                | Host where the messaging service is located. **Change only if you know what you are doing!**                             |
-| messaging.virtualHost                        | `"czertainly"`                       | RabbitMQ virtual host                                                                                                    |
-| messaging.amqp.port                          | `5672`                               | AMQP port of the messaging service. **Change only if you know what you are doing!**                                      |
-| bootstrap.proxy.amqpUrl                      | `"amqp://messaging-service:5672"`    | External AMQP URL that proxy services use to connect to RabbitMQ (may differ from internal host when using NodePort/LB) |
-| bootstrap.proxy.exchange                     | `"czertainly-proxy"`                 | RabbitMQ exchange name for proxy communication                                                                           |
-| bootstrap.proxy.responseQueue                | `"core"`                             | RabbitMQ queue name for proxy responses                                                                                  |
-| bootstrap.security.enabled                   | `false`                              | Enable the X-API-Key filter on bootstrap endpoints. When `false`, endpoints are unauthenticated.                         |
-| bootstrap.security.apiKey                    | `""`                                 | API key used to secure the bootstrap service endpoints. Required when `bootstrap.security.enabled` is `true`.            |
-| bootstrap.token.signingKey                   | `""`                                 | JWT signing key used to sign tokens for proxy services. Optional; must be at least 32 characters if set.                |
-| serviceAccount.create                        | `true`                               | Specifies whether a service account should be created                                                                    |
-| serviceAccount.annotations                   | `{}`                                 | Annotations to add to the service account                                                                                |
-| serviceAccount.name                          | `"provisioning-rabbitmq-sa"`         | The name of the service account to use                                                                                   |
+| Parameter                                    | Default value                     | Description                                                                                                              |
+|----------------------------------------------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| nameOverride                                 | `provisioning-rabbitmq`           | Override for the chart name. Used as the `app.kubernetes.io/name` selector label value and as input to the fullname helper. Pinned to keep selectors stable across chart renames; changing this requires manual cleanup of existing Deployments. |
+| fullnameOverride                             | `""`                              | Override for the fully qualified app name.                                                                               |
+| image.registry                               | `hub.omnitrustregistry.com`       | Docker registry name for the image                                                                                       |
+| image.repository                             | `ilm`                             | Docker image repository name                                                                                             |
+| image.name                                   | `provisioning-rabbitmq`           | Docker image name                                                                                                        |
+| image.tag                                    | `1.0.0`                           | Docker image tag                                                                                                         |
+| image.digest                                 | `""`                              | Docker image digest, will override tag if specified                                                                      |
+| image.pullPolicy                             | `IfNotPresent`                    | Image pull policy                                                                                                        |
+| image.pullSecrets                            | `[]`                              | Array of secret names for image pull                                                                                     |
+| image.command                                | `[]`                              | Override the default command                                                                                             |
+| image.args                                   | `[]`                              | Override the default args                                                                                                |
+| image.securityContext.runAsNonRoot           | `true`                            | Run the container as non-root user                                                                                       |
+| image.securityContext.readOnlyRootFilesystem | `true`                            | Run the container with read-only root filesystem                                                                         |
+| image.resources                              | `{}`                              | The resources for the container                                                                                          |
+| podLabels                                    | `{}`                              | Labels to be added to the pod                                                                                            |
+| podAnnotations                               | `{}`                              | Annotations to be added to the pod                                                                                       |
+| podSecurityContext                           | `{}`                              | Pod security context                                                                                                     |
+| volumes.ephemeral.type                       | `memory`                          | Ephemeral volume type to be used                                                                                         |
+| volumes.ephemeral.sizeLimit                  | `"1Mi"`                           | Ephemeral volume size limit                                                                                              |
+| volumes.ephemeral.storageClassName           | `""`                              | Ephemeral volume storage class name for `storage` type                                                                   |
+| volumes.ephemeral.custom                     | `{}`                              | Custom definition of the ephemeral volume for `custom` type                                                              |
+| logging.level                                | `"INFO"`                          | Allowed values are `"INFO"`, `"DEBUG"`, `"WARN"`, `"TRACE"`                                                             |
+| service.type                                 | `"ClusterIP"`                     | Type of the service that is exposed                                                                                      |
+| service.port                                 | `8077`                            | Port number of the exposed service                                                                                       |
+| javaOpts                                     | `""`                              | Customize Java system properties                                                                                         |
+| messaging.external.enabled                   | `false`                           | Enable external messaging                                                                                                |
+| messaging.external.host                      | `""`                              | Host where the external messaging is located                                                                             |
+| messaging.external.amqp.port                 | `""`                              | Port on which the external messaging is listening                                                                        |
+| messaging.provisionerUsername                | `"provisioner"`                   | Admin/provisioner username for managing RabbitMQ queues and exchanges                                                    |
+| messaging.provisionerPassword                | `"provisioner"`                   | Admin/provisioner password for managing RabbitMQ queues and exchanges                                                    |
+| messaging.proxyUsername                      | `"proxy"`                         | Proxy user credentials included in generated JWT tokens for proxy services                                               |
+| messaging.proxyPassword                      | `"proxy"`                         | Proxy user password included in generated JWT tokens for proxy services                                                  |
+| messaging.host                               | `"messaging-service"`             | Host where the messaging service is located. **Change only if you know what you are doing!**                             |
+| messaging.virtualHost                        | `"/"`                             | RabbitMQ virtual host                                                                                                    |
+| messaging.amqp.port                          | `5672`                            | AMQP port of the messaging service. **Change only if you know what you are doing!**                                      |
+| bootstrap.proxy.amqpUrl                      | `"amqp://messaging-service:5672"` | External AMQP URL that proxy services use to connect to RabbitMQ (may differ from internal host when using NodePort/LB) |
+| bootstrap.proxy.exchange                     | `"ilm-proxy"`                     | RabbitMQ exchange name for proxy communication                                                                           |
+| bootstrap.proxy.responseQueue                | `"core"`                          | RabbitMQ queue name for proxy responses                                                                                  |
+| bootstrap.security.enabled                   | `false`                           | Enable the X-API-Key filter on bootstrap endpoints. When `false`, endpoints are unauthenticated.                         |
+| bootstrap.security.apiKey                    | `""`                              | API key used to secure the bootstrap service endpoints. Required when `bootstrap.security.enabled` is `true`.            |
+| bootstrap.token.signingKey                   | `""`                              | JWT signing key used to sign tokens for proxy services. Optional; must be at least 32 characters if set.                |
+| serviceAccount.create                        | `true`                            | Specifies whether a service account should be created                                                                    |
+| serviceAccount.annotations                   | `{}`                              | Annotations to add to the service account                                                                                |
+| serviceAccount.name                          | `"provisioning-rabbitmq-sa"`      | The name of the service account to use                                                                                   |
 
 #### Customization parameters
 

--- a/charts/provisioning-rabbitmq/templates/provisioning-rabbitmq-deployment.yaml
+++ b/charts/provisioning-rabbitmq/templates/provisioning-rabbitmq-deployment.yaml
@@ -105,7 +105,7 @@ spec:
                   {{- end }}
                   key: messaging.amqp.port
             - name: RABBITMQ_VIRTUAL_HOST
-              value: {{ pluck "virtualHost" .Values.global.messaging .Values.messaging | compact | first | default "czertainly" | quote }}
+              value: {{ pluck "virtualHost" .Values.global.messaging .Values.messaging | compact | first | default "/" | quote }}
             - name: RABBITMQ_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/charts/provisioning-rabbitmq/values.yaml
+++ b/charts/provisioning-rabbitmq/values.yaml
@@ -148,7 +148,7 @@ messaging:
   proxyUsername: "proxy"
   proxyPassword: "proxy"
   host: "messaging-service"
-  virtualHost: "czertainly"
+  virtualHost: "/"
   amqp:
     port: 5672
 
@@ -160,7 +160,7 @@ bootstrap:
     # Set explicitly when proxies connect from outside the cluster via NodePort, LoadBalancer,
     # or a dedicated TCP ingress that differs from the internal messaging address.
     amqpUrl: ""
-    exchange: "czertainly-proxy"
+    exchange: "ilm-proxy"
     responseQueue: "core"
   security:
     # When true, the X-API-Key filter is enabled and apiKey must be set.

--- a/charts/scheduler-service/Chart.lock
+++ b/charts/scheduler-service/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.4.2-1
 - name: messaging-rabbitmq
   repository: file://../messaging-rabbitmq
-  version: 4.2.0-2-develop
-digest: sha256:a4576508e1beb9466abe899b9c9f320bf712cad0b82cb4bb23718648ae7d7f32
-generated: "2026-06-16T09:34:08.268764+02:00"
+  version: 4.2.0-3-develop
+digest: sha256:fa0470cf1e865502e106f718c46e8549c905d4e14dc1aa867d7c1e64b8e7e4a5
+generated: "2026-06-16T11:48:39.038196+02:00"

--- a/charts/scheduler-service/Chart.lock
+++ b/charts/scheduler-service/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.4.2-1
 - name: messaging-rabbitmq
   repository: file://../messaging-rabbitmq
-  version: 4.2.0-2
+  version: 4.2.0-2-develop
 digest: sha256:ef847c6eb4654184fa1d8ba95981096f221e70759e1642341791ccb66ff0cc11
 generated: "2026-06-06T14:48:56.945389+02:00"

--- a/charts/scheduler-service/Chart.lock
+++ b/charts/scheduler-service/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: messaging-rabbitmq
   repository: file://../messaging-rabbitmq
   version: 4.2.0-2-develop
-digest: sha256:ef847c6eb4654184fa1d8ba95981096f221e70759e1642341791ccb66ff0cc11
-generated: "2026-06-06T14:48:56.945389+02:00"
+digest: sha256:a4576508e1beb9466abe899b9c9f320bf712cad0b82cb4bb23718648ae7d7f32
+generated: "2026-06-16T09:34:08.268764+02:00"

--- a/charts/scheduler-service/Chart.yaml
+++ b/charts/scheduler-service/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: trustLifecycleManagement
 apiVersion: v2
-appVersion: 1.1.0
+appVersion: 1.1.1-develop
 name: scheduler-service
 description: A Helm chart for ILM platform Scheduler service.
 home: https://github.com/OmniTrustILM/ilm
@@ -16,7 +16,7 @@ dependencies:
     repository: file://../messaging-rabbitmq
     tags:
       - messaging
-    version: 4.2.0-2
+    version: 4.2.0-2-develop
     condition: messaging.local
 keywords:
   - ilm
@@ -35,4 +35,4 @@ sources:
   - https://github.com/OmniTrustILM/ilm
   - https://omnitrust.com
   - https://docs.otilm.com
-version: 1.1.0
+version: 1.1.1-develop

--- a/charts/scheduler-service/Chart.yaml
+++ b/charts/scheduler-service/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
     repository: file://../messaging-rabbitmq
     tags:
       - messaging
-    version: 4.2.0-2-develop
+    version: 4.2.0-3-develop
     condition: messaging.local
 keywords:
   - ilm

--- a/charts/scheduler-service/templates/scheduler-service-deployment.yaml
+++ b/charts/scheduler-service/templates/scheduler-service-deployment.yaml
@@ -83,7 +83,7 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.service.port | quote }}
-            - name: LOGGING_LEVEL_COM_CZERTAINLY
+            - name: LOGGING_LEVEL_COM_OTILM
               value: {{ .Values.logging.level | quote }}
             - name: JDBC_URL
               value: {{ include "ilm-lib.util.format.jdbcUrl" (list . "?characterEncoding=UTF-8") | quote }}
@@ -136,7 +136,7 @@ spec:
                   {{- end }}
                   key: messaging.password
             - name: BROKER_VIRTUAL_HOST
-              value: {{ pluck "virtualHost" .Values.global.messaging .Values.messaging | compact | first | default "czertainly" | quote }}
+              value: {{ pluck "virtualHost" .Values.global.messaging .Values.messaging | compact | first | default "/" | quote }}
             {{- if $additionalEnv }}
               {{- $additionalEnv | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
Change messaging configuration to use "/" as the default virtual host and rename exchanges/queues from "czertainly" to "ilm" (and "czertainly-proxy" to "ilm-proxy"). Update related RabbitMQ definitions, provisioning and messaging chart values, and routing/write permission patterns. Also rename logging env var LOGGING_LEVEL_COM_CZERTAINLY to LOGGING_LEVEL_COM_OTILM in ilm and scheduler-service deployments.