### PR TITLE
Add provider.status-poll queue and binding

### DIFF
--- a/charts/messaging-rabbitmq/Chart.yaml
+++ b/charts/messaging-rabbitmq/Chart.yaml
@@ -28,4 +28,4 @@ sources:
   - https://github.com/OmniTrustILM/ilm
   - https://omnitrust.com
   - https://docs.otilm.com
-version: 4.2.0-4-develop
+version: 4.2.0-3-develop

--- a/charts/messaging-rabbitmq/Chart.yaml
+++ b/charts/messaging-rabbitmq/Chart.yaml
@@ -28,4 +28,4 @@ sources:
   - https://github.com/OmniTrustILM/ilm
   - https://omnitrust.com
   - https://docs.otilm.com
-version: 4.2.0-3-develop
+version: 4.2.0-4-develop

--- a/charts/messaging-rabbitmq/templates/_definitions_json.tpl
+++ b/charts/messaging-rabbitmq/templates/_definitions_json.tpl
@@ -86,7 +86,7 @@ Example:
       "vhost": "{{ $virtualHost }}",
       "configure": "",
       "write": "^ilm(-proxy)?$",
-      "read": "^core(\\..+|-.+)?$|^time-quality\\.(config-request|results)$"
+      "read": "^core(\\..+|-.+)?$|^provider\\.status-poll$|^time-quality\\.(config-request|results)$"
     },
     {
       "user": "{{ $timeQualityMonitorUsername }}",

--- a/charts/messaging-rabbitmq/templates/_definitions_json.tpl
+++ b/charts/messaging-rabbitmq/templates/_definitions_json.tpl
@@ -160,6 +160,13 @@ Example:
       "arguments": {}
     },
     {
+      "name": "provider.status-poll",
+      "vhost": "{{ $virtualHost }}",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+    {
       "name": "core",
       "vhost": "{{ $virtualHost }}",
       "durable": true,
@@ -241,6 +248,14 @@ Example:
       "destination": "core.events",
       "destination_type": "queue",
       "routing_key": "event",
+      "arguments": {}
+    },
+    {
+      "source": "ilm",
+      "vhost": "{{ $virtualHost }}",
+      "destination": "provider.status-poll",
+      "destination_type": "queue",
+      "routing_key": "provider.status-poll",
       "arguments": {}
     },
     {


### PR DESCRIPTION
Adds a plain durable `provider.status-poll` queue and its `ilm`-exchange binding to the messaging-rabbitmq definitions, so OmniTrustILM/core's async certificate-status polling (OmniTrustILM/core#1602) can consume/publish on it.

Backoff is DB-driven in core, so this is an ordinary queue — no `rabbitmq_delayed_message_exchange` plugin, no delayed exchange, no special arguments. Mirrors the existing `core.*` queue/binding shape.

Closes #305
Part of epic OmniTrustILM/ilm#110.
