### PR TITLE
Always test and republish ilm umbrella on any subchart change

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -45,6 +45,15 @@ jobs:
             echo "✅ Charts changed"
             echo "changed=true" >> $GITHUB_ENV
 
+            # The ilm umbrella packages a copy of every subchart, so a
+            # subchart-only change still needs the umbrella linted. Record
+            # whether the umbrella itself is already in the changed set.
+            if echo "$changed" | grep -qx "charts/ilm"; then
+              echo "umbrella_in_set=true" >> $GITHUB_ENV
+            else
+              echo "umbrella_in_set=false" >> $GITHUB_ENV
+            fi
+
             echo "changed_charts<<EOF" >> $GITHUB_ENV
             echo "$changed" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
@@ -88,6 +97,15 @@ jobs:
       - name: Run chart-testing (lint)
         if: env.changed == 'true'
         run: ct lint --target-branch "$BASE_BRANCH" --check-version-increment=false
+
+      # ct only lints charts whose own files changed, so a subchart-only change
+      # skips the umbrella. Lint it explicitly to catch a broken umbrella render
+      # before the heavier install tests run.
+      - name: Lint ilm umbrella (subchart change)
+        if: env.changed == 'true' && env.umbrella_in_set != 'true'
+        run: |
+          helm dependency update charts/ilm --skip-refresh
+          ct lint --target-branch "$BASE_BRANCH" --charts charts/ilm --check-version-increment=false
 
       # Package up PR context for downstream workflow_run
       - name: Prepare PR context artifact

--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Lint ilm umbrella (subchart change)
         if: env.changed == 'true' && env.umbrella_in_set != 'true'
         run: |
-          helm dependency update charts/ilm --skip-refresh
+          helm dependency update charts/ilm
           ct lint --target-branch "$BASE_BRANCH" --charts charts/ilm --check-version-increment=false
 
       # Package up PR context for downstream workflow_run

--- a/.github/workflows/publish_charts.yml
+++ b/.github/workflows/publish_charts.yml
@@ -55,6 +55,19 @@ jobs:
             echo "✅ Charts changed"
             echo "changed=true" >> $GITHUB_ENV
 
+            # The ilm umbrella packages a frozen copy of every subchart, so any
+            # chart change must also republish the umbrella — otherwise the
+            # deployed umbrella artifact keeps the old subchart copy. If it is
+            # not already in the changed set, add it so the version check
+            # validates it and it is released last.
+            if echo "$changed" | grep -qx "charts/ilm"; then
+              echo "umbrella_in_set=true" >> $GITHUB_ENV
+            else
+              echo "umbrella_in_set=false" >> $GITHUB_ENV
+              echo "ℹ️ Adding charts/ilm so the umbrella is republished"
+              changed=$(printf '%s\ncharts/ilm' "$changed")
+            fi
+
             echo "changed_charts<<EOF" >> $GITHUB_ENV
             echo "$changed" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
@@ -105,6 +118,15 @@ jobs:
           else
             ct lint --target-branch "$BRANCH" --since HEAD^1 --check-version-increment=false
           fi
+
+      # When only a subchart changed, the umbrella is force-added to the publish
+      # set above but not linted by the --since lint (which uses git diff). Lint
+      # it explicitly so a broken umbrella render is caught before publishing.
+      - name: Lint ilm umbrella (subchart change)
+        if: env.changed == 'true' && env.umbrella_in_set != 'true'
+        run: |
+          helm dependency update charts/ilm --skip-refresh
+          ct lint --target-branch "$BRANCH" --charts charts/ilm --check-version-increment=false
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@main

--- a/.github/workflows/publish_charts.yml
+++ b/.github/workflows/publish_charts.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Lint ilm umbrella (subchart change)
         if: env.changed == 'true' && env.umbrella_in_set != 'true'
         run: |
-          helm dependency update charts/ilm --skip-refresh
+          helm dependency update charts/ilm
           ct lint --target-branch "$BRANCH" --charts charts/ilm --check-version-increment=false
 
       - name: Install Cosign

--- a/.github/workflows/test_charts.yml
+++ b/.github/workflows/test_charts.yml
@@ -211,12 +211,12 @@ jobs:
       - name: Lint ilm umbrella (subchart change)
         if: env.changed == 'true' && env.umbrella_in_set != 'true'
         run: |
-          helm dependency update charts/ilm --skip-refresh
+          helm dependency update charts/ilm
           ct lint --remote upstream --target-branch "$BASE_BRANCH" --charts charts/ilm --check-version-increment=false
 
       - name: Install ilm umbrella (subchart change)
         if: env.changed == 'true' && env.umbrella_in_set != 'true'
-        run: ct install --remote upstream --namespace chart-testing --charts charts/ilm --helm-extra-args "--timeout 600s"
+        run: ct install --remote upstream --namespace chart-testing --charts charts/ilm
 
       - name: Finalize GitHub Check
         if: always()

--- a/.github/workflows/test_charts.yml
+++ b/.github/workflows/test_charts.yml
@@ -127,6 +127,15 @@ jobs:
             echo "✅ Charts changed"
             echo "changed=true" >> $GITHUB_ENV
 
+            # The ilm umbrella packages a frozen copy of every subchart, so a
+            # subchart-only change still needs the umbrella linted and installed.
+            # Record whether the umbrella itself is already in the changed set.
+            if echo "$changed" | grep -qx "charts/ilm"; then
+              echo "umbrella_in_set=true" >> $GITHUB_ENV
+            else
+              echo "umbrella_in_set=false" >> $GITHUB_ENV
+            fi
+
             echo "changed_charts<<EOF" >> $GITHUB_ENV
             echo "$changed" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
@@ -195,6 +204,19 @@ jobs:
       - name: Run chart-testing (install)
         if: env.changed == 'true'
         run: ct install --remote upstream --namespace chart-testing --target-branch "$BASE_BRANCH" --excluded-charts ilm-lib
+
+      # ct only tests charts whose own files changed, so a subchart-only change
+      # skips the umbrella — yet the umbrella is what gets deployed. Lint and
+      # fully install it so the change is validated end-to-end before publish.
+      - name: Lint ilm umbrella (subchart change)
+        if: env.changed == 'true' && env.umbrella_in_set != 'true'
+        run: |
+          helm dependency update charts/ilm --skip-refresh
+          ct lint --remote upstream --target-branch "$BASE_BRANCH" --charts charts/ilm --check-version-increment=false
+
+      - name: Install ilm umbrella (subchart change)
+        if: env.changed == 'true' && env.umbrella_in_set != 'true'
+        run: ct install --remote upstream --namespace chart-testing --charts charts/ilm --helm-extra-args "--timeout 600s"
 
       - name: Finalize GitHub Check
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ charts/<name>/
 - **Testing** (`test_charts.yml`) — Dispatched after PR check; runs lint + install tests on KinD cluster with PostgreSQL 18 and mailserver services
 - **Publishing** (`publish_charts.yml`) — On push to main or tag; packages, pushes to `oci://hub.omnitrustregistry.com/ilm-helm`, signs with Cosign
 - Charts are published in dependency order; `ilm-lib` excluded from install tests (library chart)
+- The `ilm` umbrella packages a frozen copy of every subchart, so a change to *any* chart also triggers the umbrella — even when `charts/ilm`'s own files are untouched. All three workflows detect this case (`umbrella_in_set`) and additionally lint the umbrella (`check_pr.yml`, `publish_charts.yml`), install-test it on KinD (`test_charts.yml`), and repackage + republish it (`publish_charts.yml`). This keeps the deployed umbrella artifact in sync with its subcharts (it would otherwise embed the pre-change copy)
 
 ## Development Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,4 +99,5 @@ charts/<name>/
 - Test values for various deployment scenarios are in `for-testing/` and `charts/ilm/ci/`
 - Dummy certificates in `dummy-certificates/` are included by default for dev/testing
 - When adding a new chart, add it to `update-all-dependencies.sh` and if it's a subchart of the umbrella, add a dependency entry in `charts/ilm/Chart.yaml`
+- When bumping a subchart's `version`, also bump its matching dependency `version:` in `charts/ilm/Chart.yaml` (the umbrella pins each subchart to an exact version) and run `helm dependency update charts/ilm`. CI now runs `helm dependency update charts/ilm` on any chart change, so a mismatch fails the workflow with a cryptic `can't get a valid version for dependency` error. A version bump also puts `charts/ilm` directly in the changed set.
 - Java packages still use `com.czertainly` namespace — the `LOGGING_LEVEL_COM_CZERTAINLY` env var in deployment templates is intentional and will be updated when Java code is refactored


### PR DESCRIPTION
The `ilm` umbrella packages a frozen copy of every subchart, so a change to any subchart was never reflected in the deployed `ilm` umbrella artifact. The `check_pr`, `test_charts` and `publish_charts` workflows now lint, install-test and republish the `ilm` umbrella whenever any chart changes.

Closes #309