### PR TITLE
Add Helm chart to deploy OT PKI Connector

### DIFF
--- a/charts/ilm/Chart.lock
+++ b/charts/ilm/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 1.1.6-1
 - name: otpki-connector
   repository: file://../otpki-connector
-  version: 1.0.0-develop
+  version: 1.0.0-1-develop
 - name: x509-compliance-provider
   repository: file://../x509-compliance-provider
   version: 1.3.1-3
@@ -74,5 +74,5 @@ dependencies:
 - name: pg-bouncer
   repository: file://../pg-bouncer
   version: 1.24.1-p1-2
-digest: sha256:336ba3fc2d1a676b53a2cbbd034d0d9b02348be35589a19f9d67855dbc562b55
-generated: "2026-06-30T11:51:07.4492907+02:00"
+digest: sha256:284cc7f594ffc1dc53d5a07c27bc8b9288f6b9c51f1e5ca1d5acb940e5e8ecee
+generated: "2026-06-30T15:47:22.5964126+02:00"

--- a/charts/ilm/Chart.lock
+++ b/charts/ilm/Chart.lock
@@ -14,6 +14,9 @@ dependencies:
 - name: pyadcs-connector
   repository: file://../pyadcs-connector
   version: 1.1.6-1
+- name: otpki-connector
+  repository: file://../otpki-connector
+  version: 1.0.0-develop
 - name: x509-compliance-provider
   repository: file://../x509-compliance-provider
   version: 1.3.1-3
@@ -71,5 +74,5 @@ dependencies:
 - name: pg-bouncer
   repository: file://../pg-bouncer
   version: 1.24.1-p1-2
-digest: sha256:fb9a26001a458be007c8dbe75e5a7817ce1cf8a76f6b12b807680abf65cf8250
-generated: "2026-06-16T11:40:55.605634+02:00"
+digest: sha256:336ba3fc2d1a676b53a2cbbd034d0d9b02348be35589a19f9d67855dbc562b55
+generated: "2026-06-30T11:51:07.4492907+02:00"

--- a/charts/ilm/Chart.yaml
+++ b/charts/ilm/Chart.yaml
@@ -49,6 +49,14 @@ dependencies:
       - discovery-provider
     version: 1.1.6-1
     alias: pyAdcsConnector
+  - condition: otpkiConnector.enabled
+    name: otpki-connector
+    # repository: oci://hub.omnitrustregistry.com/ilm-helm
+    repository: file://../otpki-connector
+    tags:
+      - authority-provider
+    version: 1.0.0-develop
+    alias: otpkiConnector
   - condition: x509ComplianceProvider.enabled
     name: x509-compliance-provider
     # repository: oci://hub.omnitrustregistry.com/ilm-helm

--- a/charts/ilm/Chart.yaml
+++ b/charts/ilm/Chart.yaml
@@ -55,7 +55,7 @@ dependencies:
     repository: file://../otpki-connector
     tags:
       - authority-provider
-    version: 1.0.0-develop
+    version: 1.0.0-1-develop
     alias: otpkiConnector
   - condition: x509ComplianceProvider.enabled
     name: x509-compliance-provider

--- a/charts/ilm/templates/hooks/register-connectors-job.yaml
+++ b/charts/ilm/templates/hooks/register-connectors-job.yaml
@@ -83,6 +83,11 @@ spec:
             -d '{"name": "PyADCS-Connector","url": "http://pyadcs-connector-service:{{ .Values.pyAdcsConnector.service.port }}","authType": "none"}' \
             http://core-service:{{ .Values.service.port }}/api/v1/connector/register &&
             {{- end }}
+            {{- if .Values.otpkiConnector.enabled }}
+            curl -X POST -k -H 'content-type: application/json' \
+            -d '{"name": "OTPKI-Connector", "version": "v2", "url": "http://otpki-connector-service:{{ .Values.otpkiConnector.service.port }}","authType": "none", "customAttributes": []}' \
+            http://core-service:{{ .Values.service.port }}/api/v2/connector/register &&
+            {{- end }}
             {{- if .Values.hashicorpVaultConnector.enabled }}
             curl -X POST -k -H 'content-type: application/json' \
             -d '{"name": "HashiCorp-Vault-Connector","url": "http://hashicorp-vault-connector-service:{{ .Values.hashicorpVaultConnector.service.port }}","authType": "none"}' \

--- a/charts/ilm/values.yaml
+++ b/charts/ilm/values.yaml
@@ -588,6 +588,10 @@ pyAdcsConnector:
   nameOverride: pyadcs-connector
   enabled: false
 
+otpkiConnector:
+  nameOverride: otpki-connector
+  enabled: false
+
 hashicorpVaultConnector:
   nameOverride: hashicorp-vault-connector
   enabled: false

--- a/charts/otpki-connector/.helmignore
+++ b/charts/otpki-connector/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/otpki-connector/Chart.lock
+++ b/charts/otpki-connector/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: ilm-lib
+  repository: file://../ilm-lib
+  version: 1.4.2-1
+digest: sha256:c9343afd64d3fa30364d4c0e013af3a550e0bfb6af1590b9ffd1d082bb457ec8
+generated: "2026-06-30T11:37:00.000000+02:00"

--- a/charts/otpki-connector/Chart.yaml
+++ b/charts/otpki-connector/Chart.yaml
@@ -29,4 +29,4 @@ sources:
   - https://github.com/OmniTrustILM/ilm
   - https://omnitrust.com
   - https://docs.otilm.com
-version: 1.0.0-develop
+version: 1.0.0-1-develop

--- a/charts/otpki-connector/Chart.yaml
+++ b/charts/otpki-connector/Chart.yaml
@@ -1,0 +1,32 @@
+annotations:
+  category: trustLifecycleManagement
+apiVersion: v2
+appVersion: 1.0.0
+name: otpki-connector
+description: A Helm chart for OT PKI Connector for ILM platform.
+home: https://github.com/OmniTrustILM/ilm
+icon: https://raw.githubusercontent.com/OmniTrustILM/ilm/main/icon/ot-icon-color.svg
+dependencies:
+  - name: ilm-lib
+    # repository: oci://hub.omnitrustregistry.com/ilm-helm
+    repository: file://../ilm-lib
+    version: 1.4.2-1
+keywords:
+  - ilm
+  - trust
+  - management
+  - lifecycle
+  - platform
+  - otpki
+  - authority
+  - provider
+maintainers:
+  - name: OmniTrustILM
+    email: ilm@omnitrust.com
+    url: https://github.com/OmniTrustILM/helm-charts
+type: application
+sources:
+  - https://github.com/OmniTrustILM/ilm
+  - https://omnitrust.com
+  - https://docs.otilm.com
+version: 1.0.0-develop

--- a/charts/otpki-connector/README.md
+++ b/charts/otpki-connector/README.md
@@ -1,0 +1,179 @@
+# OT PKI Connector - ILM
+
+This repository contains [Helm](https://helm.sh/) charts as part of the ILM platform.
+
+The OT PKI Connector is a stateless Go service implementing the **Authority Provider v3**
+interface. It is configured entirely through environment variables and requires no
+database. See [OmniTrustILM/otpki-connector](https://github.com/OmniTrustILM/otpki-connector)
+for the connector itself.
+
+## Prerequisites
+- Kubernetes 1.19+
+- Helm 3.8.0+
+
+## Using this Chart
+
+### Installation
+
+**Create namespace**
+
+We’ll need to define a Kubernetes namespace where the resources created by the Chart should be installed:
+```bash
+kubectl create namespace ilm
+```
+
+**Clone this chart**
+
+> **Note**
+> You can also use `--set` options for the helm to apply configuration for the chart.
+
+Now edit the `values.yaml` according to your desired stated, see [Configurable parameters](#configurable-parameters) for more information.
+
+**Install**
+
+For the basic installation, run:
+```bash
+helm install --namespace ilm -f values.yaml ilm-otpki-connector charts/otpki-connector
+```
+
+**Save your configuration**
+
+Always make sure you save the `values.yaml` and all `--set` and `--set-file` options you used. You will need to use the same options when you upgrade to new versions with Helm. In case you are changing the configuration, save the new configuration.
+
+### Upgrade
+
+> **Warning**
+> Be sure that you always save your previous configuration!
+
+For upgrading the installation, update your configuration and run:
+```bash
+helm upgrade --namespace ilm -f values.yaml ilm-otpki-connector charts/otpki-connector
+```
+
+### Uninstall
+
+You can use the `helm uninstall` command to uninstall the application:
+```bash
+helm uninstall --namespace ilm ilm-otpki-connector
+```
+
+## Configurable parameters
+
+You can find current values in the [values.yaml](values.yaml).
+You can also Specify each parameter using the `--set` or `--set-file` argument to `helm install`.
+
+### Global parameters
+
+Global values are used to define common parameters for the chart and all its sub-charts by exactly the same name.
+
+| Parameter                                  | Default value | Description                                                        |
+|--------------------------------------------|---------------|--------------------------------------------------------------------|
+| global.replicaCount                        | `1`           | Number of replicas for the application                             |
+| global.image.registry                      | `""`          | Global docker registry name                                        |
+| global.image.repository                    | `""`          | Global docker image repository name                                |
+| global.image.pullSecrets                   | `[]`          | Global array of secret names for image pull                        |
+| global.volumes.ephemeral.type              | `""`          | Global ephemeral volume type to be used                            |
+| global.volumes.ephemeral.sizeLimit         | `""`          | Global ephemeral volume size limit                                 |
+| global.volumes.ephemeral.storageClassName  | `""`          | Global ephemeral volume storage class name for `storage` type      |
+| global.volumes.ephemeral.custom            | `{}`          | Global custom definition of the ephemeral volume for `custom` type |
+| global.trusted.certificates                | `""`          | Global PEM bundle of trusted CA certificates                       |
+| global.httpProxy                           | `""`          | Global HTTP proxy for outbound connections                         |
+| global.httpsProxy                          | `""`          | Global HTTPS proxy for outbound connections                        |
+| global.noProxy                             | `""`          | Global comma-separated no-proxy list                               |
+| global.initContainers                      | `[]`          | Global init containers                                             |
+| global.sidecarContainers                   | `[]`          | Global sidecar containers                                          |
+| global.additionalVolumes                   | `[]`          | Global additional volumes                                          |
+| global.additionalVolumeMounts              | `[]`          | Global additional volume mounts                                    |
+| global.additionalPorts                     | `[]`          | Global additional ports                                            |
+| global.additionalEnv.variables             | `[]`          | Global additional environment variables                            |
+| global.additionalEnv.secrets               | `[]`          | Global additional environment secrets                              |
+| global.additionalEnv.configMaps            | `[]`          | Global additional environment config maps                          |
+
+### Local parameters
+
+The following values may be configured:
+
+| Parameter                                    | Default value               | Description                                                                                                                                                                                                                                     |
+|----------------------------------------------|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| nameOverride                                 | `otpki-connector`           | Override for the chart name. Used as the `app.kubernetes.io/name` selector label value and as input to the fullname helper. Pinned to keep selectors stable across chart renames; changing this requires manual cleanup of existing Deployments. |
+| fullnameOverride                             | `""`                        | Override for the fully qualified app name.                                                                                                                                                                                                     |
+| image.registry                               | `hub.omnitrustregistry.com` | Docker registry name for the image                                                                                                                                                                                                            |
+| image.repository                             | `ilm`                       | Docker image repository name                                                                                                                                                                                                                   |
+| image.name                                   | `otpki-connector`           | Docker image name                                                                                                                                                                                                                             |
+| image.tag                                    | `1.0.0`                     | Docker image tag                                                                                                                                                                                                                              |
+| image.digest                                 | `""`                        | Docker image digest, will override tag if specified                                                                                                                                                                                          |
+| image.pullPolicy                             | `IfNotPresent`              | Image pull policy                                                                                                                                                                                                                            |
+| image.pullSecrets                            | `[]`                        | Array of secret names for image pull                                                                                                                                                                                                          |
+| image.command                                | `[]`                        | Override the default command                                                                                                                                                                                                                  |
+| image.args                                   | `[]`                        | Override the default args                                                                                                                                                                                                                     |
+| image.securityContext.runAsNonRoot           | `true`                      | Run the container as non-root user                                                                                                                                                                                                          |
+| image.securityContext.readOnlyRootFilesystem | `true`                      | Run the container with read-only root filesystem                                                                                                                                                                                            |
+| image.resources                              | `{}`                        | The resources for the container                                                                                                                                                                                                             |
+| podLabels                                    | `{}`                        | Labels to be added to the pod                                                                                                                                                                                                               |
+| podAnnotations                               | `{}`                        | Annotations to be added to the pod                                                                                                                                                                                                          |
+| podSecurityContext                           | `{}`                        | Pod security context                                                                                                                                                                                                                        |
+| volumes.ephemeral.type                       | `memory`                    | Ephemeral volume type to be used                                                                                                                                                                                                            |
+| volumes.ephemeral.sizeLimit                  | `"1Mi"`                     | Ephemeral volume size limit                                                                                                                                                                                                                 |
+| volumes.ephemeral.storageClassName           | `""`                        | Ephemeral volume storage class name for `storage` type                                                                                                                                                                                     |
+| volumes.ephemeral.custom                     | `{}`                        | Custom definition of the ephemeral volume for `custom` type                                                                                                                                                                                |
+| service.type                                 | `"ClusterIP"`               | Type of the service that is exposed                                                                                                                                                                                                         |
+| service.port                                 | `8080`                      | Port number of the exposed service. Passed to the connector as `PORT`                                                                                                                                                                        |
+| logging.level                                | `"INFO"`                    | Connector log level (`LOG_LEVEL`). Allowed values are `"DEBUG"`, `"INFO"`, `"WARN"`, `"ERROR"`                                                                                                                                                |
+| trusted.certificates                         | `""`                        | PEM bundle of trusted CA certificates, passed to the connector as `TRUSTED_CERTIFICATES`. Stored in the `trusted-certificates-otpki-connector` Secret. Overridden by `global.trusted.certificates` when set                                    |
+| otel.serviceName                             | `"otpki-connector"`         | OpenTelemetry service name (`OTEL_SERVICE_NAME`)                                                                                                                                                                                              |
+| otel.exporterOtlpEndpoint                    | `""`                        | OTLP trace exporter endpoint (`OTEL_EXPORTER_OTLP_ENDPOINT`). Tracing is a no-op when empty                                                                                                                                                   |
+| tracing.samplingProbability                  | `"1.0"`                     | Ratio sampler probability `0.0`–`1.0` (`TRACING_SAMPLING_PROBABILITY`)                                                                                                                                                                        |
+| otpki.loginPasswordKey                       | `""`                        | HMAC-SHA256 key for deriving end-entity passwords (`OTPKI_LOGIN_PASSWORD_KEY`). Stored in the `otpki-connector-secret` Secret when set; empty means keyless (loginId verbatim)                                                                |
+| httpProxy                                    | `""`                        | HTTP proxy for outbound connections (`HTTP_PROXY`)                                                                                                                                                                                            |
+| httpsProxy                                   | `""`                        | HTTPS proxy for outbound connections (`HTTPS_PROXY`)                                                                                                                                                                                          |
+| noProxy                                      | `""`                        | Comma-separated no-proxy list (`NO_PROXY`)                                                                                                                                                                                                    |
+| serviceAccount.create                        | `true`                      | Specifies whether a service account should be created                                                                                                                                                                                       |
+| serviceAccount.annotations                   | `{}`                        | Annotations to add to the service account                                                                                                                                                                                                   |
+| serviceAccount.name                          | `"otpki-connector-sa"`      | The name of the service account to use. If not set and create is true, a name is generated using the fullname template                                                                                                                       |
+
+#### Customization parameters
+
+| Parameter                | Default value | Description                        |
+|--------------------------|---------------|------------------------------------|
+| initContainers           | `[]`          | Init containers                    |
+| sidecarContainers        | `[]`          | Sidecar containers                 |
+| additionalVolumes        | `[]`          | Additional volumes                 |
+| additionalVolumeMounts   | `[]`          | Additional volume mounts           |
+| additionalPorts          | `[]`          | Additional ports                   |
+| additionalEnv.variables  | `[]`          | Additional environment variables   |
+| additionalEnv.secrets    | `[]`          | Additional environment secrets     |
+| additionalEnv.configMaps | `[]`          | Additional environment config maps |
+
+#### Probes parameters
+
+The liveness and startup probes are wired to `/v2/health/liveness` and the readiness probe to `/v2/health/readiness`.
+For more details about probes, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
+
+| Parameter                                  | Default value | Description                                                                        |
+|--------------------------------------------|---------------|------------------------------------------------------------------------------------|
+| image.probes.liveness.enabled              | `false`       | Enable/disable liveness probe                                                      |
+| image.probes.liveness.custom               | `{}`          | Custom liveness probe command. When defined, it will override the default command  |
+| image.probes.liveness.initialDelaySeconds  | `10`          | Initial delay seconds for liveness probe                                           |
+| image.probes.liveness.timeoutSeconds       | `5`           | Timeout seconds for liveness probe                                                 |
+| image.probes.liveness.periodSeconds        | `10`          | Period seconds for liveness probe                                                  |
+| image.probes.liveness.successThreshold     | `1`           | Success threshold for liveness probe                                               |
+| image.probes.liveness.failureThreshold     | `3`           | Failure threshold for liveness probe                                               |
+| image.probes.readiness.enabled             | `true`        | Enable/disable readiness probe                                                     |
+| image.probes.readiness.custom              | `{}`          | Custom readiness probe command. When defined, it will override the default command |
+| image.probes.readiness.initialDelaySeconds | `5`           | Initial delay seconds for readiness probe                                          |
+| image.probes.readiness.timeoutSeconds      | `5`           | Timeout seconds for readiness probe                                                |
+| image.probes.readiness.periodSeconds       | `10`          | Period seconds for readiness probe                                                 |
+| image.probes.readiness.successThreshold    | `1`           | Success threshold for readiness probe                                              |
+| image.probes.readiness.failureThreshold    | `3`           | Failure threshold for readiness probe                                              |
+| image.probes.startup.enabled               | `true`        | Enable/disable startup probe                                                       |
+| image.probes.startup.custom                | `{}`          | Custom startup probe command. When defined, it will override the default command   |
+| image.probes.startup.initialDelaySeconds   | `10`          | Initial delay seconds for startup probe                                            |
+| image.probes.startup.timeoutSeconds        | `5`           | Timeout seconds for startup probe                                                  |
+| image.probes.startup.periodSeconds         | `10`          | Period seconds for startup probe                                                   |
+| image.probes.startup.successThreshold      | `1`           | Success threshold for startup probe                                                |
+| image.probes.startup.failureThreshold      | `10`          | Failure threshold for startup probe                                                |
+
+### Additional parameters
+
+Additional parameters may be found in the [values.yaml](values.yaml) and dependencies.
+See dependent charts for the description of available parameters.

--- a/charts/otpki-connector/README.md
+++ b/charts/otpki-connector/README.md
@@ -27,7 +27,7 @@ kubectl create namespace ilm
 > **Note**
 > You can also use `--set` options for the helm to apply configuration for the chart.
 
-Now edit the `values.yaml` according to your desired stated, see [Configurable parameters](#configurable-parameters) for more information.
+Now edit the `values.yaml` according to your desired state, see [Configurable parameters](#configurable-parameters) for more information.
 
 **Install**
 
@@ -60,7 +60,7 @@ helm uninstall --namespace ilm ilm-otpki-connector
 ## Configurable parameters
 
 You can find current values in the [values.yaml](values.yaml).
-You can also Specify each parameter using the `--set` or `--set-file` argument to `helm install`.
+You can also specify each parameter using the `--set` or `--set-file` argument to `helm install`.
 
 ### Global parameters
 

--- a/charts/otpki-connector/ci/develop-values.yaml
+++ b/charts/otpki-connector/ci/develop-values.yaml
@@ -1,0 +1,4 @@
+image:
+  tag: develop-latest
+  pullSecrets:
+    - ilmcred

--- a/charts/otpki-connector/templates/NOTES.txt
+++ b/charts/otpki-connector/templates/NOTES.txt
@@ -1,0 +1,7 @@
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+APP VERSION: {{ .Chart.AppVersion }}
+
+** Please be patient while the chart is being deployed **
+
+Follow the steps described in the documentation in order to register the connector within the ILM platform.

--- a/charts/otpki-connector/templates/_helpers.tpl
+++ b/charts/otpki-connector/templates/_helpers.tpl
@@ -1,0 +1,151 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "otpki-connector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "otpki-connector.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "otpki-connector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "otpki-connector.labels" -}}
+helm.sh/chart: {{ include "otpki-connector.chart" . }}
+{{ include "otpki-connector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "otpki-connector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "otpki-connector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "otpki-connector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "otpki-connector.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the image name
+*/}}
+{{- define "otpki-connector.image" -}}
+{{ include "ilm-lib.images.image" (dict "image" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the image name of the curl
+*/}}
+{{- define "otpki-connector.curl.image" -}}
+{{ include "ilm-lib.images.image" (dict "image" .Values.curl.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the image pull secret names
+*/}}
+{{- define "otpki-connector.imagePullSecrets" -}}
+{{ include "ilm-lib.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the ephemeral volume configuration
+*/}}
+{{- define "otpki-connector.ephemeralVolume" -}}
+{{ include "ilm-lib.volumes.ephemeral" (dict "volumes" .Values.volumes "global" .Values.global.volumes) }}
+{{- end -}}
+
+{{/*
+Render init containers, if any
+*/}}
+{{- define "otpki-connector.customization.initContainers" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.initContainers .Values.initContainers) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render sidecar containers, if any
+*/}}
+{{- define "otpki-connector.customization.sidecarContainers" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.sidecarContainers .Values.sidecarContainers) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render additional volumes, if any
+*/}}
+{{- define "otpki-connector.customization.volumes" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalVolumes .Values.additionalVolumes) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render additional volume mounts, if any
+*/}}
+{{- define "otpki-connector.customization.volumeMounts" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalVolumeMounts .Values.additionalVolumeMounts) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render customized ports, if any
+*/}}
+{{- define "otpki-connector.customization.ports" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalPorts .Values.additionalPorts) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render customized environment variables, if any
+*/}}
+{{- define "otpki-connector.customization.env" -}}
+{{- include "ilm-lib.customizations.render.yaml" ( dict "parts" (list .Values.global.additionalEnv.variables .Values.additionalEnv.variables) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render customized environment variables from configmaps and secrets, if any
+*/}}
+{{- define "otpki-connector.customization.envFrom" -}}
+{{- include "ilm-lib.customizations.render.configMapEnv" ( dict "parts" (list .Values.global.additionalEnv.configMaps .Values.additionalEnv.configMaps) "context" $ ) }}
+{{- include "ilm-lib.customizations.render.secretEnv" ( dict "parts" (list .Values.global.additionalEnv.secrets .Values.additionalEnv.secrets) "context" $ ) }}
+{{- end -}}
+
+{{/*
+Render customized command and arguments, if any
+*/}}
+{{- define "otpki-connector.image.command" -}}
+{{- include "ilm-lib.tplvalues.render" (dict "value" .Values.image.command "context" $) }}
+{{- end -}}
+
+{{- define "otpki-connector.image.args" -}}
+{{- include "ilm-lib.tplvalues.render" (dict "value" .Values.image.args "context" $) }}
+{{- end -}}

--- a/charts/otpki-connector/templates/otpki-connector-deployment.yaml
+++ b/charts/otpki-connector/templates/otpki-connector-deployment.yaml
@@ -1,0 +1,185 @@
+{{- $replicaCount := pluck "replicaCount" .Values.global .Values | compact | first }}
+{{- $httpProxy := pluck "httpProxy" .Values.global .Values | compact | first }}
+{{- $httpsProxy := pluck "httpsProxy" .Values.global .Values | compact | first }}
+{{- $noProxy := pluck "noProxy" .Values.global .Values | compact | first }}
+{{- $additionalInitContainers := (include "otpki-connector.customization.initContainers" $) }}
+{{- $additionalSidecarContainers := (include "otpki-connector.customization.sidecarContainers" $) }}
+{{- $additionalVolumes := (include "otpki-connector.customization.volumes" $) }}
+{{- $additionalVolumeMounts := (include "otpki-connector.customization.volumeMounts" $) }}
+{{- $additionalEnv := (include "otpki-connector.customization.env" $) }}
+{{- $additionalEnvFrom := (include "otpki-connector.customization.envFrom" $) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otpki-connector-deployment
+  labels:
+    {{- include "otpki-connector.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ $replicaCount | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "otpki-connector.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "otpki-connector.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+        # when the list of the trusted certificates is changed, restart deployment
+        checksum/trusted-certificates-local: {{ include (print $.Template.BasePath "/trusted-certificates-secret.yaml") . | sha256sum }}
+        {{- if .Values.global.trusted.certificates }}
+        checksum/trusted-certificates-global: {{ include ("ilm-lib.trusted.certificates.secret.global") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.otpki.loginPasswordKey }}
+        # when the login password key changes, restart deployment
+        checksum/secret: {{ include (print $.Template.BasePath "/otpki-connector-secret.yaml") . | sha256sum }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "otpki-connector.imagePullSecrets" . | indent 6 }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- .Values.podSecurityContext | toYaml | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ template "otpki-connector.serviceAccountName" . }}
+      {{- if $additionalInitContainers }}
+      initContainers:
+        {{- $additionalInitContainers | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: otpki-connector
+          image: {{ include "otpki-connector.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.image.command }}
+          command: {{- include "otpki-connector.image.command" . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.image.args }}
+          args: {{- include "otpki-connector.image.args" . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: PORT
+              value: {{ .Values.service.port | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.logging.level | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.otel.serviceName | quote }}
+            {{- if .Values.otel.exporterOtlpEndpoint }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.otel.exporterOtlpEndpoint | quote }}
+            {{- end }}
+            {{- if ne (.Values.tracing.samplingProbability | toString) "" }}
+            - name: TRACING_SAMPLING_PROBABILITY
+              value: {{ .Values.tracing.samplingProbability | quote }}
+            {{- end }}
+            {{- if .Values.global.trusted.certificates }}
+            - name: TRUSTED_CERTIFICATES
+              valueFrom:
+                secretKeyRef:
+                  name: trusted-certificates
+                  key: ca.crt
+            {{- else if .Values.trusted.certificates }}
+            - name: TRUSTED_CERTIFICATES
+              valueFrom:
+                secretKeyRef:
+                  name: trusted-certificates-{{ .Chart.Name | lower }}
+                  key: ca.crt
+            {{- end }}
+            {{- if .Values.otpki.loginPasswordKey }}
+            - name: OTPKI_LOGIN_PASSWORD_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: otpki-connector-secret
+                  key: login_password_key
+            {{- end }}
+            {{- if $httpProxy }}
+            - name: HTTP_PROXY
+              value: {{ $httpProxy }}
+            {{- end }}
+            {{- if $httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ $httpsProxy }}
+            {{- end }}
+            {{- if $noProxy }}
+            - name: NO_PROXY
+              value: {{ $noProxy }}
+            {{- end }}
+            {{- if $additionalEnv }}
+              {{- $additionalEnv | nindent 12 }}
+            {{- end }}
+          {{- if $additionalEnvFrom }}
+          envFrom:
+            {{- $additionalEnvFrom | indent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          {{- if .Values.image.securityContext }}
+          securityContext: {{- .Values.image.securityContext | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.image.probes.liveness.enabled }}
+          livenessProbe:
+            {{- if .Values.image.probes.liveness.custom }}
+            {{- toYaml .Values.image.probes.liveness.custom | nindent 12 }}
+            {{- else }}
+            httpGet:
+              path: /v2/health/liveness
+              port: {{ .Values.service.port }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.image.probes.liveness.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.image.probes.liveness.timeoutSeconds }}
+            periodSeconds: {{ .Values.image.probes.liveness.periodSeconds }}
+            successThreshold: {{ .Values.image.probes.liveness.successThreshold }}
+            failureThreshold: {{ .Values.image.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.image.probes.readiness.enabled }}
+          readinessProbe:
+            {{- if .Values.image.probes.readiness.custom }}
+            {{- toYaml .Values.image.probes.readiness.custom | nindent 12 }}
+            {{- else }}
+            httpGet:
+              path: /v2/health/readiness
+              port: {{ .Values.service.port }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.image.probes.readiness.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.image.probes.readiness.timeoutSeconds }}
+            periodSeconds: {{ .Values.image.probes.readiness.periodSeconds }}
+            successThreshold: {{ .Values.image.probes.readiness.successThreshold }}
+            failureThreshold: {{ .Values.image.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.image.probes.startup.enabled }}
+          startupProbe:
+            {{- if .Values.image.probes.startup.custom }}
+            {{- toYaml .Values.image.probes.startup.custom | nindent 12 }}
+            {{- else }}
+            httpGet:
+              path: /v2/health/liveness
+              port: {{ .Values.service.port }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.image.probes.startup.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.image.probes.startup.timeoutSeconds }}
+            periodSeconds: {{ .Values.image.probes.startup.periodSeconds }}
+            successThreshold: {{ .Values.image.probes.startup.successThreshold }}
+            failureThreshold: {{ .Values.image.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.image.resources }}
+          resources: {{- toYaml .Values.image.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: ephemeral
+            {{- if $additionalVolumeMounts }}
+              {{- $additionalVolumeMounts | nindent 12 }}
+            {{- end }}
+        {{- if $additionalSidecarContainers }}
+          {{- $additionalSidecarContainers | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: ephemeral
+          {{- include "otpki-connector.ephemeralVolume" . | indent 10 }}
+        {{- if $additionalVolumes }}
+          {{- $additionalVolumes | nindent 8 }}
+        {{- end }}

--- a/charts/otpki-connector/templates/otpki-connector-secret.yaml
+++ b/charts/otpki-connector/templates/otpki-connector-secret.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.otpki.loginPasswordKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: otpki-connector-secret
+data:
+  login_password_key: {{ .Values.otpki.loginPasswordKey | b64enc | quote }}
+{{- end }}

--- a/charts/otpki-connector/templates/otpki-connector-service.yaml
+++ b/charts/otpki-connector/templates/otpki-connector-service.yaml
@@ -1,0 +1,17 @@
+{{- $additionalPorts := (include "otpki-connector.customization.ports" $) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: otpki-connector-service
+  labels:
+    {{- include "otpki-connector.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      protocol: "TCP"
+    {{- if $additionalPorts }}
+      {{- $additionalPorts | nindent 4 }}
+    {{- end }}
+  selector:
+    {{- include "otpki-connector.selectorLabels" . | nindent 4 }}

--- a/charts/otpki-connector/templates/rbac/service-account.yaml
+++ b/charts/otpki-connector/templates/rbac/service-account.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "otpki-connector.serviceAccountName" . }}
+  labels:
+    {{- include "otpki-connector.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/otpki-connector/templates/tests/test-connection.yaml
+++ b/charts/otpki-connector/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "otpki-connector.fullname" . }}-test-connection"
+  labels:
+    {{- include "otpki-connector.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: curl
+      image: {{ include "otpki-connector.curl.image" . }}
+      command:
+        - /bin/sh
+        - -c
+        - |
+          curl --silent --retry 5 --retry-delay 5 --retry-all-errors otpki-connector-service:{{ .Values.service.port }}/v2/health/readiness
+  restartPolicy: Never

--- a/charts/otpki-connector/templates/trusted-certificates-secret.yaml
+++ b/charts/otpki-connector/templates/trusted-certificates-secret.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.trusted.certificates }}
+{{- include "ilm-lib.trusted.certificates.secret.local" (list . "otpki-connector.trusted.certificates.secret") -}}
+{{- end }}
+
+{{- define "otpki-connector.trusted.certificates.secret" -}}
+data:
+  ca.crt: {{ required "List of trusted certificates is required: .Values.trusted.certificates!" .Values.trusted.certificates | b64enc }}
+{{- end -}}

--- a/charts/otpki-connector/values.yaml
+++ b/charts/otpki-connector/values.yaml
@@ -1,0 +1,231 @@
+# Default values for otpki-connector.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: otpki-connector
+fullnameOverride: ""
+
+# Global parameters that will overwrite local parameters
+global:
+  replicaCount: 1
+  image:
+    registry: ""
+    repository: ""
+    # array of secret names
+    pullSecrets: []
+  volumes:
+    ephemeral:
+      type: ""
+      sizeLimit: ""
+      storageClassName: ""
+      custom: {}
+  trusted:
+    certificates: ""
+  httpProxy: ""
+  httpsProxy: ""
+  noProxy: ""
+  # additional init containers that will be added to each pod
+  # - name: some-image
+  #   image: some-image
+  #   imagePullPolicy: IfNotPresent
+  #   securityContext:
+  #     runAsNonRoot: true
+  #   ports:
+  #     - name: port
+  #       containerPort: "{{ $.Values.container.port }}"
+  initContainers: []
+  # additional sidecar containers that will be added to each pod
+  # see the sample of init containers above
+  sidecarContainers: []
+  # additional volumes that will be added to each pod
+  # - name: additional-volume
+  #   configMap:
+  #     name: additional-volume
+  additionalVolumes: []
+  # additional volume mounts that will be added to each pod
+  # - name: additional-volume
+  #   mountPath: /opt/app
+  #   readOnly: true
+  additionalVolumeMounts: []
+  # additional service ports that will be added to each pod
+  # - name: other-port
+  #   port: 8080
+  #   targetPort: 8080
+  additionalPorts: []
+  # additional environment variables that will be added to each pod
+  additionalEnv:
+    # - name: SOME_ENV
+    #   value: "some-value"
+    variables: []
+    # list of config maps to be added as environment variables
+    configMaps: []
+    # list of secrets to be added as environment variables
+    secrets: []
+
+trusted:
+  certificates: ""
+
+httpProxy: ""
+httpsProxy: ""
+noProxy: ""
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+replicaCount: 1
+
+service:
+  type: "ClusterIP"
+  port: 8080
+
+image:
+  # default registry name
+  registry: hub.omnitrustregistry.com
+  repository: ilm
+  name: otpki-connector
+  tag: 1.0.0
+  # the digest to be used instead of the tag
+  digest: ""
+  pullPolicy: IfNotPresent
+  # array of secret names
+  pullSecrets: []
+  # custom command and args
+  command: []
+  args: []
+  # default security context
+  securityContext:
+    runAsNonRoot: true
+    # runAsUser: 10001
+    readOnlyRootFilesystem: true
+  # probes configuration
+  probes:
+    liveness:
+      enabled: false
+      # custom probe command, will override the default one
+      custom: {}
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      # custom probe command, will override the default one
+      custom: {}
+      initialDelaySeconds: 5
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+    startup:
+      enabled: true
+      # custom probe command, will override the default one
+      custom: {}
+      initialDelaySeconds: 10
+      timeoutSeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 10
+  resources: {}
+    # We follow recommendations and general guidelines to manage resources from:
+    # https://master.sdk.operatorframework.io/docs/best-practices/managing-resources/
+    # We recommend default requests for CPU and Memory, leaving the limits as a conscious
+    # choice for the user. If you do want to specify your own resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources'.
+    # requests:
+    #   cpu: 100m
+    #   memory: 400M
+    # limits: {}
+
+curl:
+  image:
+    # default registry name
+    registry: hub.omnitrustregistry.com
+    repository: ilm
+    name: curl
+    tag: 8.16.0
+    # the digest to be used instead of the tag
+    digest: ""
+    pullPolicy: IfNotPresent
+    # array of secret names
+    pullSecrets: []
+    # custom command and args
+    command: []
+    args: []
+    # default security context
+    securityContext:
+      runAsNonRoot: true
+      # runAsUser: 100
+      readOnlyRootFilesystem: true
+    # it does not make sense to have probes for curl
+    resources: {}
+      # We follow recommendations and general guidelines to manage resources from:
+      # https://master.sdk.operatorframework.io/docs/best-practices/managing-resources/
+      # We recommend default requests for CPU and Memory, leaving the limits as a conscious
+      # choice for the user. If you do want to specify your own resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources'.
+      # requests:
+      #   cpu: 50m
+      #   memory: 150M
+      # limits: {}
+
+# customization of the chart
+initContainers: []
+sidecarContainers: []
+additionalVolumes: []
+additionalVolumeMounts: []
+additionalPorts: []
+additionalEnv:
+  variables: []
+  configMaps: []
+  secrets: []
+
+volumes:
+  ephemeral:
+    # available types are: memory, storage, custom
+    type: memory
+    sizeLimit: "1Mi"
+    storageClassName: ""
+    custom: {}
+    #  emptyDir:
+    #    sizeLimit: "10Mi"
+    #    medium: "Memory"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "otpki-connector-sa"
+
+logging:
+  level: "INFO"
+
+# OpenTelemetry tracing. Tracing is a no-op until exporterOtlpEndpoint is set.
+otel:
+  serviceName: "otpki-connector"
+  exporterOtlpEndpoint: ""
+
+tracing:
+  # Ratio sampler probability (0.0–1.0) applied when tracing is enabled.
+  # A value of "0" disables sampling; set to an empty string to defer to the
+  # connector's own default.
+  samplingProbability: "1.0"
+
+otpki:
+  # HMAC-SHA256 key for deriving end-entity passwords (OTPKI_LOGIN_PASSWORD_KEY).
+  # When empty, the connector uses the loginId verbatim (keyless mode).
+  # When set, it is stored in the otpki-connector-secret Secret.
+  loginPasswordKey: ""
+
+podLabels: {}
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000

--- a/update-all-dependencies.sh
+++ b/update-all-dependencies.sh
@@ -51,6 +51,9 @@ helm dependency update charts/messaging-rabbitmq --skip-refresh
 echo "Updating dependencies for network-discovery-provider..."
 helm dependency update charts/network-discovery-provider --skip-refresh
 
+echo "Updating dependencies for otpki-connector..."
+helm dependency update charts/otpki-connector --skip-refresh
+
 echo "Updating dependencies for pyadcs-connector..."
 helm dependency update charts/pyadcs-connector --skip-refresh
 


### PR DESCRIPTION
## Summary

Adds `charts/otpki-connector` to deploy the **OT PKI Connector** — the Go, stateless, database-less Authority Provider v3 connector (`OmniTrustILM/otpki-connector`) — and wires it into the `ilm` umbrella. Modeled on `pyadcs-connector`, with all database wiring removed.

## What changed

**New chart `charts/otpki-connector`** (`1.0.0-develop`, appVersion `1.0.0`):
- Deployment exposes the HTTP port (default `8080`) via a Service; all connector env vars are configurable in `values.yaml`: `PORT`, `LOG_LEVEL`, `TRUSTED_CERTIFICATES`, `OTPKI_LOGIN_PASSWORD_KEY`, `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `TRACING_SAMPLING_PROBABILITY`, `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`.
- Liveness/startup probes wired to `/v2/health/liveness`, readiness to `/v2/health/readiness` (liveness off by default, matching sibling connectors).
- `TRUSTED_CERTIFICATES` injected as an env var (PEM bundle) from the trusted-certificates Secret — matching the connector's env contract rather than a mounted CA file.
- Optional `OTPKI_LOGIN_PASSWORD_KEY` stored in a chart Secret, rendered only when set.
- README documents every value.

**Umbrella wiring (`charts/ilm`):**
- Optional dependency with condition `otpkiConnector.enabled` (default `false`), tagged `authority-provider`.
- v2-only registration (`/api/v2/connector/register`, `version: v2`) in the register-connectors hook — the connector serves a `/v2/*` API (v3 provider interface) with no `/v1` surface.
- Added to `update-all-dependencies.sh`; `charts/ilm/Chart.lock` regenerated.

## Testing

- `helm lint` clean on `charts/otpki-connector` and `charts/ilm`.
- `helm template` renders correctly with all conditionals exercised: trusted certs (local + global), login-key Secret, OTLP endpoint, proxies, and tracing sampling (including the `0` = disabled case). Umbrella renders with `otpkiConnector.enabled=true` (subchart resources + v2 registration), and OTPKI is correctly absent when disabled.

Resolves #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
